### PR TITLE
refactor(stm): Reuse the cached unsafe SRS in the SNARK test setups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.2", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.3", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.3 (08-05-2026)
+
+### Changed
+
+- Updated the test handling of the unsafe srs. It is now shared across more tests.
+- Updated the cache of the test circuit keys so they can be shared more broadly.
+- Removed most of the srs downsizing used in the tests.
+
 ## 0.12.2 (08-04-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.2"
+version = "0.12.3"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -181,18 +181,18 @@ pub(crate) fn build_shared_recursive_context(
     let universal_kzg_parameters = build_deterministic_params(shared_srs_degree);
     let universal_verifier_params = universal_kzg_parameters.verifier_params();
 
-    let (certificate_commitment_parameters, recursive_commitment_parameters) =
-        if CERTIFICATE_CIRCUIT_DEGREE == shared_srs_degree {
-            (
-                universal_kzg_parameters.clone(),
-                build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE),
-            )
+    let params_for = |degree| {
+        if degree == shared_srs_degree {
+            universal_kzg_parameters.clone()
         } else {
-            (
-                build_deterministic_params(CERTIFICATE_CIRCUIT_DEGREE),
-                universal_kzg_parameters.clone(),
-            )
-        };
+            build_deterministic_params(degree)
+        }
+    };
+
+    let (certificate_commitment_parameters, recursive_commitment_parameters) = (
+        params_for(CERTIFICATE_CIRCUIT_DEGREE),
+        params_for(RECURSIVE_CIRCUIT_DEGREE),
+    );
 
     let certificate_verifying_key = NonRecursiveCircuitVerifyingKey::new(zk_lib::setup_vk(
         &certificate_commitment_parameters,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -173,19 +173,6 @@ pub(crate) fn build_deterministic_params(circuit_degree: u32) -> ParamsKZG<Bls12
     ParamsKZG::<Bls12>::unsafe_setup(circuit_degree, ChaCha20Rng::seed_from_u64(ASSET_SEED))
 }
 
-/// Derives circuit-specific commitment parameters from a shared universal SRS.
-pub(super) fn derive_commitment_params(
-    universal_kzg_parameters: &ParamsKZG<Bls12>,
-    shared_srs_degree: u32,
-    circuit_degree: u32,
-) -> ParamsKZG<Bls12> {
-    let mut commitment_parameters = universal_kzg_parameters.clone();
-    if circuit_degree < shared_srs_degree {
-        commitment_parameters.downsize(circuit_degree);
-    }
-    commitment_parameters
-}
-
 /// Builds the shared verifier-side recursive setup from the deterministic SRS.
 pub(crate) fn build_shared_recursive_context(
     setup: &AssetGenerationSetup,
@@ -194,16 +181,18 @@ pub(crate) fn build_shared_recursive_context(
     let universal_kzg_parameters = build_deterministic_params(shared_srs_degree);
     let universal_verifier_params = universal_kzg_parameters.verifier_params();
 
-    let certificate_commitment_parameters = derive_commitment_params(
-        &universal_kzg_parameters,
-        shared_srs_degree,
-        CERTIFICATE_CIRCUIT_DEGREE,
-    );
-    let recursive_commitment_parameters = derive_commitment_params(
-        &universal_kzg_parameters,
-        shared_srs_degree,
-        RECURSIVE_CIRCUIT_DEGREE,
-    );
+    let (certificate_commitment_parameters, recursive_commitment_parameters) =
+        if CERTIFICATE_CIRCUIT_DEGREE == shared_srs_degree {
+            (
+                universal_kzg_parameters.clone(),
+                build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE),
+            )
+        } else {
+            (
+                build_deterministic_params(CERTIFICATE_CIRCUIT_DEGREE),
+                universal_kzg_parameters.clone(),
+            )
+        };
 
     let certificate_verifying_key = NonRecursiveCircuitVerifyingKey::new(zk_lib::setup_vk(
         &certificate_commitment_parameters,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
@@ -21,8 +21,6 @@ use crate::{
 use super::setup::build_deterministic_params;
 
 pub(crate) fn golden_recursive_circuit_verification_key_bytes() -> Vec<u8> {
-    let srs_for_recursive_circuit = build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE);
-
     let small_parameters = Parameters {
         m: 10,
         k: 1,
@@ -32,8 +30,8 @@ pub(crate) fn golden_recursive_circuit_verification_key_bytes() -> Vec<u8> {
     let circuit = StmCertificateCircuit::try_new(&small_parameters, merkle_tree_depth).unwrap();
     let circuit_degree = MidnightCircuit::from_relation(&circuit, None).k();
 
-    let mut srs_for_non_recursive_circuit = srs_for_recursive_circuit.clone();
-    srs_for_non_recursive_circuit.downsize(circuit_degree);
+    let srs_for_non_recursive_circuit = build_deterministic_params(circuit_degree);
+    let srs_for_recursive_circuit = build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE);
 
     let circuit_verification_key = NonRecursiveCircuitVerifyingKey::new(
         midnight_zk_stdlib::setup_vk(&srs_for_non_recursive_circuit, &circuit),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
@@ -31,7 +31,11 @@ pub(crate) fn golden_recursive_circuit_verification_key_bytes() -> Vec<u8> {
     let circuit_degree = MidnightCircuit::from_relation(&circuit, None).k();
 
     let srs_for_non_recursive_circuit = build_deterministic_params(circuit_degree);
-    let srs_for_recursive_circuit = build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE);
+    let srs_for_recursive_circuit = if circuit_degree == RECURSIVE_CIRCUIT_DEGREE {
+        srs_for_non_recursive_circuit.clone()
+    } else {
+        build_deterministic_params(RECURSIVE_CIRCUIT_DEGREE)
+    };
 
     let circuit_verification_key = NonRecursiveCircuitVerifyingKey::new(
         midnight_zk_stdlib::setup_vk(&srs_for_non_recursive_circuit, &circuit),

--- a/mithril-stm/src/circuits/test_utils/file_mutex.rs
+++ b/mithril-stm/src/circuits/test_utils/file_mutex.rs
@@ -166,21 +166,16 @@ mod tests {
         assert_ne!(baseline.directory(), other_depth.directory());
         assert_ne!(baseline.directory(), other_seed.directory());
 
-        // The IVC setup cache additionally folds in the SRS degree and both production verifying keys
-        // as a circuit-version salt; a change in either must also resolve to a different directory.
+        // The IVC setup cache folds in both production verifying keys as a circuit-version salt, like
+        // the certificate-key cache and it omits the SRS degree for the same reason.
         let ivc_baseline = FileMutex::for_shared_cache(
             "ivc-setup",
-            &[b"parameters-a", b"depth-4", b"degree-19", b"circuit-vk-1"],
-        );
-        let other_degree = FileMutex::for_shared_cache(
-            "ivc-setup",
-            &[b"parameters-a", b"depth-4", b"degree-20", b"circuit-vk-1"],
+            &[b"parameters-a", b"depth-4", b"circuit-vk-1"],
         );
         let other_circuit_version = FileMutex::for_shared_cache(
             "ivc-setup",
-            &[b"parameters-a", b"depth-4", b"degree-19", b"circuit-vk-2"],
+            &[b"parameters-a", b"depth-4", b"circuit-vk-2"],
         );
-        assert_ne!(ivc_baseline.directory(), other_degree.directory());
         assert_ne!(ivc_baseline.directory(), other_circuit_version.directory());
     }
 }

--- a/mithril-stm/src/circuits/trusted_setup.rs
+++ b/mithril-stm/src/circuits/trusted_setup.rs
@@ -192,9 +192,10 @@ impl Default for TrustedSetupProvider {
 }
 
 /// Seed for the deterministic unsafe SRS used by the tests; it pins the SRS's tau. Test key caches
-/// fold in this seed so they stay correct if it ever changes. The IVC setup cache also folds in the
-/// SRS degree; the certificate-key cache omits it, since keygen downsizes the seed-pinned SRS to the
-/// certificate circuit's own degree, so the oversized degree never affects the certificate key.
+/// fold in this seed so they stay correct if it ever changes. Both the certificate-key and IVC setup
+/// caches omit the SRS degree: keygen always downsizes the seed-pinned SRS to the target circuit
+/// degree before deriving keys, so the oversized starting degree never affects the derived keys —
+/// only `TrustedSetupProvider::with_unsafe_srs`'s own file layout, which nests by degree.
 #[cfg(any(test, feature = "benchmark-internals"))]
 pub(crate) const UNSAFE_SRS_SEED: u64 = 42;
 

--- a/mithril-stm/src/circuits/trusted_setup.rs
+++ b/mithril-stm/src/circuits/trusted_setup.rs
@@ -130,13 +130,13 @@ impl TrustedSetupProvider {
             .with_extension("temp");
         let final_path = self.local_srs_folder_path.join(MITHRIL_CIRCUIT_SRS_FILENAME);
 
-        let mut temporary_file = File::create(&temp_path)
+        let mut temp_file = File::create(&temp_path)
             .with_context(|| format!("Failed to create temporary SRS file at {temp_path:?}."))?;
-        temporary_file.write_all(srs_bytes)?;
-        temporary_file
+        temp_file.write_all(srs_bytes)?;
+        temp_file
             .sync_all()
             .with_context(|| "Failed to fsync temporary SRS file before rename.")?;
-        drop(temporary_file);
+        drop(temp_file);
 
         std::fs::rename(temp_path, final_path)?;
 
@@ -202,16 +202,15 @@ pub(crate) const UNSAFE_SRS_SEED: u64 = 42;
 #[cfg(any(test, feature = "benchmark-internals"))]
 impl TrustedSetupProvider {
     /// Builds a `TrustedSetupProvider` backed by a freshly generated unsafe SRS of degree `k`, written
-    /// to `base_dir/{k}/srs/srs-parameters` with a matching SHA256 hash so the provider's hash check passes.
+    /// to `base_dir/degree-{k}/srs/srs-parameters` with empty hash as it should never be checked.
     /// For tests and benchmarks only.
     pub(crate) fn with_unsafe_srs(base_dir: &std::path::Path, k: u32) -> Self {
-        let base_dir = base_dir.join(k.to_string());
-        let srs_file = base_dir
-            .join(MITHRIL_CIRCUIT_SRS_FOLDER)
-            .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+        let degree_k_dir = base_dir.join(format!("degree-{k}"));
+        let srs_dir = degree_k_dir.join(MITHRIL_CIRCUIT_SRS_FOLDER);
+        let srs_file = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME);
 
         if srs_file.exists() {
-            return Self::new(base_dir, "", "", Duration::from_secs(600));
+            return Self::new(degree_k_dir, "", "", Duration::from_secs(600));
         }
 
         let srs = ParamsKZG::<Bls12>::unsafe_setup(k, ChaCha20Rng::seed_from_u64(UNSAFE_SRS_SEED));
@@ -219,26 +218,25 @@ impl TrustedSetupProvider {
         srs.write_custom(&mut srs_bytes, SerdeFormat::RawBytesUnchecked)
             .unwrap();
 
-        let srs_dir = base_dir.join(MITHRIL_CIRCUIT_SRS_FOLDER);
         create_dir_all(&srs_dir).unwrap();
 
-        let temp_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME).with_extension("temp");
-        let final_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME);
-        let mut temporary_file = File::create(&temp_path)
-            .with_context(|| format!("Failed to create temporary SRS file at {temp_path:?}."))
+        let temp_path = srs_file.with_extension("temp");
+        let mut temp_file = File::create(&temp_path)
+            .with_context(|| {
+                format!("Failed to create temporary unsafe SRS file at {temp_path:?}.")
+            })
             .unwrap();
-        temporary_file.write_all(&srs_bytes).unwrap();
-        temporary_file
+        temp_file.write_all(&srs_bytes).unwrap();
+        temp_file
             .sync_all()
-            .with_context(|| "Failed to fsync temporary SRS file before rename.")
+            .with_context(|| "Failed to fsync temporary unsafe SRS file before rename.")
             .unwrap();
-        drop(temporary_file);
+        drop(temp_file);
 
-        std::fs::rename(temp_path, final_path).unwrap();
+        std::fs::rename(temp_path, srs_file).unwrap();
 
-        let expected_hash = hex::encode(Sha256::digest(&srs_bytes));
-
-        Self::new(base_dir, expected_hash, "", Duration::from_secs(600))
+        // No hash needed for the test srs
+        Self::new(degree_k_dir, "", "", Duration::from_secs(600))
     }
 }
 
@@ -500,11 +498,11 @@ mod tests {
 
             let expected_srs_path = temp_dir
                 .path()
-                .join(k.to_string())
+                .join(format!("degree-{k}"))
                 .join(MITHRIL_CIRCUIT_SRS_FOLDER)
                 .join(MITHRIL_CIRCUIT_SRS_FILENAME);
             assert!(expected_srs_path.exists());
-            assert!(provider.get_trusted_setup_parameters().is_ok());
+            provider.get_trusted_setup_parameters().unwrap();
         }
 
         #[test]
@@ -516,12 +514,12 @@ mod tests {
 
             let srs_path_k1 = temp_dir
                 .path()
-                .join("1")
+                .join("degree-1")
                 .join(MITHRIL_CIRCUIT_SRS_FOLDER)
                 .join(MITHRIL_CIRCUIT_SRS_FILENAME);
             let srs_path_k2 = temp_dir
                 .path()
-                .join("2")
+                .join("degree-2")
                 .join(MITHRIL_CIRCUIT_SRS_FOLDER)
                 .join(MITHRIL_CIRCUIT_SRS_FILENAME);
 
@@ -534,30 +532,13 @@ mod tests {
         }
 
         #[test]
-        fn is_deterministic_for_the_same_degree_across_different_base_dirs() {
-            let temp_dir_a = tempfile::tempdir_in("/tmp").unwrap();
-            let temp_dir_b = tempfile::tempdir_in("/tmp").unwrap();
-            let k = 1;
-
-            let provider_a = TrustedSetupProvider::with_unsafe_srs(temp_dir_a.path(), k);
-            let provider_b = TrustedSetupProvider::with_unsafe_srs(temp_dir_b.path(), k);
-
-            let srs_subpath = std::path::Path::new(&k.to_string())
-                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
-                .join(MITHRIL_CIRCUIT_SRS_FILENAME);
-            let bytes_a = std::fs::read(temp_dir_a.path().join(&srs_subpath)).unwrap();
-            let bytes_b = std::fs::read(temp_dir_b.path().join(&srs_subpath)).unwrap();
-
-            assert_eq!(bytes_a, bytes_b);
-            assert!(provider_a.get_trusted_setup_parameters().is_ok());
-            assert!(provider_b.get_trusted_setup_parameters().is_ok());
-        }
-
-        #[test]
         fn does_not_regenerate_or_overwrite_an_existing_srs_file() {
             let temp_dir = tempfile::tempdir_in("/tmp").unwrap();
             let k = 1;
-            let srs_dir = temp_dir.path().join(k.to_string()).join(MITHRIL_CIRCUIT_SRS_FOLDER);
+            let srs_dir = temp_dir
+                .path()
+                .join(format!("degree-{k}"))
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER);
             std::fs::create_dir_all(&srs_dir).unwrap();
             let srs_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME);
             std::fs::write(&srs_path, b"sentinel-content-not-a-real-srs").unwrap();
@@ -577,7 +558,7 @@ mod tests {
 
             let temp_path = temp_dir
                 .path()
-                .join(k.to_string())
+                .join(format!("degree-{k}"))
                 .join(MITHRIL_CIRCUIT_SRS_FOLDER)
                 .join(MITHRIL_CIRCUIT_SRS_FILENAME)
                 .with_extension("temp");

--- a/mithril-stm/src/circuits/trusted_setup.rs
+++ b/mithril-stm/src/circuits/trusted_setup.rs
@@ -201,21 +201,42 @@ pub(crate) const UNSAFE_SRS_SEED: u64 = 42;
 #[cfg(any(test, feature = "benchmark-internals"))]
 impl TrustedSetupProvider {
     /// Builds a `TrustedSetupProvider` backed by a freshly generated unsafe SRS of degree `k`, written
-    /// to `base_dir/srs/srs-parameters` with a matching SHA256 hash so the provider's hash check passes.
+    /// to `base_dir/{k}/srs/srs-parameters` with a matching SHA256 hash so the provider's hash check passes.
     /// For tests and benchmarks only.
     pub(crate) fn with_unsafe_srs(base_dir: &std::path::Path, k: u32) -> Self {
+        let base_dir = base_dir.join(k.to_string());
+        let srs_file = base_dir
+            .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+            .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+
+        if srs_file.exists() {
+            return Self::new(base_dir, "", "", Duration::from_secs(600));
+        }
+
         let srs = ParamsKZG::<Bls12>::unsafe_setup(k, ChaCha20Rng::seed_from_u64(UNSAFE_SRS_SEED));
         let mut srs_bytes = Vec::new();
-        srs.write_custom(&mut srs_bytes, SerdeFormat::RawBytes).unwrap();
+        srs.write_custom(&mut srs_bytes, SerdeFormat::RawBytesUnchecked)
+            .unwrap();
 
         let srs_dir = base_dir.join(MITHRIL_CIRCUIT_SRS_FOLDER);
         create_dir_all(&srs_dir).unwrap();
-        File::create(srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME))
-            .unwrap()
-            .write_all(&srs_bytes)
+
+        let temp_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME).with_extension("temp");
+        let final_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME);
+        let mut temporary_file = File::create(&temp_path)
+            .with_context(|| format!("Failed to create temporary SRS file at {temp_path:?}."))
             .unwrap();
+        temporary_file.write_all(&srs_bytes).unwrap();
+        temporary_file
+            .sync_all()
+            .with_context(|| "Failed to fsync temporary SRS file before rename.")
+            .unwrap();
+        drop(temporary_file);
+
+        std::fs::rename(temp_path, final_path).unwrap();
 
         let expected_hash = hex::encode(Sha256::digest(&srs_bytes));
+
         Self::new(base_dir, expected_hash, "", Duration::from_secs(600))
     }
 }
@@ -466,6 +487,102 @@ mod tests {
         assert!(result.is_err());
     }
 
+    mod with_unsafe_srs {
+        use super::*;
+
+        #[test]
+        fn creates_srs_file_nested_under_degree_subdirectory_and_loads_successfully() {
+            let temp_dir = tempfile::tempdir_in("/tmp").unwrap();
+            let k = 1;
+
+            let provider = TrustedSetupProvider::with_unsafe_srs(temp_dir.path(), k);
+
+            let expected_srs_path = temp_dir
+                .path()
+                .join(k.to_string())
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+                .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+            assert!(expected_srs_path.exists());
+            assert!(provider.get_trusted_setup_parameters().is_ok());
+        }
+
+        #[test]
+        fn uses_separate_subdirectory_and_produces_distinct_files_per_degree() {
+            let temp_dir = tempfile::tempdir_in("/tmp").unwrap();
+
+            TrustedSetupProvider::with_unsafe_srs(temp_dir.path(), 1);
+            TrustedSetupProvider::with_unsafe_srs(temp_dir.path(), 2);
+
+            let srs_path_k1 = temp_dir
+                .path()
+                .join("1")
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+                .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+            let srs_path_k2 = temp_dir
+                .path()
+                .join("2")
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+                .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+
+            assert!(srs_path_k1.exists());
+            assert!(srs_path_k2.exists());
+            assert_ne!(
+                std::fs::read(srs_path_k1).unwrap(),
+                std::fs::read(srs_path_k2).unwrap()
+            );
+        }
+
+        #[test]
+        fn is_deterministic_for_the_same_degree_across_different_base_dirs() {
+            let temp_dir_a = tempfile::tempdir_in("/tmp").unwrap();
+            let temp_dir_b = tempfile::tempdir_in("/tmp").unwrap();
+            let k = 1;
+
+            let provider_a = TrustedSetupProvider::with_unsafe_srs(temp_dir_a.path(), k);
+            let provider_b = TrustedSetupProvider::with_unsafe_srs(temp_dir_b.path(), k);
+
+            let srs_subpath = std::path::Path::new(&k.to_string())
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+                .join(MITHRIL_CIRCUIT_SRS_FILENAME);
+            let bytes_a = std::fs::read(temp_dir_a.path().join(&srs_subpath)).unwrap();
+            let bytes_b = std::fs::read(temp_dir_b.path().join(&srs_subpath)).unwrap();
+
+            assert_eq!(bytes_a, bytes_b);
+            assert!(provider_a.get_trusted_setup_parameters().is_ok());
+            assert!(provider_b.get_trusted_setup_parameters().is_ok());
+        }
+
+        #[test]
+        fn does_not_regenerate_or_overwrite_an_existing_srs_file() {
+            let temp_dir = tempfile::tempdir_in("/tmp").unwrap();
+            let k = 1;
+            let srs_dir = temp_dir.path().join(k.to_string()).join(MITHRIL_CIRCUIT_SRS_FOLDER);
+            std::fs::create_dir_all(&srs_dir).unwrap();
+            let srs_path = srs_dir.join(MITHRIL_CIRCUIT_SRS_FILENAME);
+            std::fs::write(&srs_path, b"sentinel-content-not-a-real-srs").unwrap();
+
+            TrustedSetupProvider::with_unsafe_srs(temp_dir.path(), k);
+
+            let bytes_after = std::fs::read(&srs_path).unwrap();
+            assert_eq!(bytes_after, b"sentinel-content-not-a-real-srs");
+        }
+
+        #[test]
+        fn leaves_no_temporary_file_behind_after_generation() {
+            let temp_dir = tempfile::tempdir_in("/tmp").unwrap();
+            let k = 1;
+
+            TrustedSetupProvider::with_unsafe_srs(temp_dir.path(), k);
+
+            let temp_path = temp_dir
+                .path()
+                .join(k.to_string())
+                .join(MITHRIL_CIRCUIT_SRS_FOLDER)
+                .join(MITHRIL_CIRCUIT_SRS_FILENAME)
+                .with_extension("temp");
+            assert!(!temp_path.exists());
+        }
+    }
     mod golden {
         use super::*;
 

--- a/mithril-stm/src/proof_system/halo2_snark/setup.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/setup.rs
@@ -79,29 +79,21 @@ impl SnarkProverSetup {
         })
     }
 
-    /// Builds a [`SnarkProverSetup`] from a deterministic, oversized unsafe SRS, exercising the real
-    /// `load` path without the production SRS. Mirrors `IvcSnarkProverSetup::build_for_test` on the
-    /// recursive side. Shared by the slow certificate tests through a content-keyed cache keyed by the
-    /// protocol parameters, Merkle-tree depth, the unsafe SRS seed, and the production verifying key as
-    /// a circuit-version salt, so the certificate key is computed once and reused across tests and
-    /// runs.
+    /// Builds an [`SnarkProverSetup`] from a deterministic unsafe SRS with degree `RECURSIVE_CIRCUIT_DEGREE`
+    /// using [`Self::build_for_test_degree`].
     #[cfg(test)]
     pub(crate) fn build_for_test(
         parameters: &Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Self> {
-        Self::build_for_test_with_unsafe_srs_degree(
-            parameters,
-            merkle_tree_depth,
-            RECURSIVE_CIRCUIT_DEGREE,
-        )
+        Self::build_for_test_degree(parameters, merkle_tree_depth, RECURSIVE_CIRCUIT_DEGREE)
     }
 
-    /// As [`Self::build_for_test`], but generates the unsafe SRS at `unsafe_srs_degree` instead of
-    /// exactly [`RECURSIVE_CIRCUIT_DEGREE`]. This removes the need to downsize in [`Self::load`] if
-    /// the input degree matches the circuit one.
+    /// Builds an [`SnarkProverSetup`] from a deterministic unsafe SRS with degree determined by the input
+    /// `unsafe_srs_degree`.
+    /// Uses a cache for the unsafe SRS to avoid regenerating it when a SRS of the correct degree already exists
     #[cfg(test)]
-    pub(crate) fn build_for_test_with_unsafe_srs_degree(
+    pub(crate) fn build_for_test_degree(
         parameters: &crate::Parameters,
         merkle_tree_depth: u32,
         unsafe_srs_degree: u32,

--- a/mithril-stm/src/proof_system/halo2_snark/setup.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/setup.rs
@@ -90,6 +90,22 @@ impl SnarkProverSetup {
         parameters: &Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Self> {
+        Self::build_for_test_with_unsafe_srs_degree(
+            parameters,
+            merkle_tree_depth,
+            RECURSIVE_CIRCUIT_DEGREE,
+        )
+    }
+
+    /// As [`Self::build_for_test`], but generates the unsafe SRS at `unsafe_srs_degree` instead of
+    /// exactly [`RECURSIVE_CIRCUIT_DEGREE`]. This removes the need to downsize in [`Self::load`] if
+    /// the input degree matches the circuit one.
+    #[cfg(test)]
+    pub(crate) fn build_for_test_with_unsafe_srs_degree(
+        parameters: &crate::Parameters,
+        merkle_tree_depth: u32,
+        unsafe_srs_degree: u32,
+    ) -> StmResult<Self> {
         let parameters_bytes = parameters.to_bytes()?;
         let depth_bytes = merkle_tree_depth.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();
@@ -107,7 +123,7 @@ impl SnarkProverSetup {
         let _key_cache_lock = cache.lock()?;
 
         let trusted_setup_provider =
-            TrustedSetupProvider::with_unsafe_srs(&cache_directory, RECURSIVE_CIRCUIT_DEGREE);
+            TrustedSetupProvider::with_unsafe_srs(&cache_directory, unsafe_srs_degree);
         let circuit = StmCertificateCircuit::try_new(parameters, merkle_tree_depth)?;
         let provider = KeyProvider::new(cache_directory, "non-recursive", &[], circuit);
         Self::load(&trusted_setup_provider, &provider)

--- a/mithril-stm/src/proof_system/halo2_snark/setup.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/setup.rs
@@ -79,7 +79,7 @@ impl SnarkProverSetup {
         })
     }
 
-    /// Builds an [`SnarkProverSetup`] from a deterministic unsafe SRS with degree `RECURSIVE_CIRCUIT_DEGREE`
+    /// Builds a [`SnarkProverSetup`] from a deterministic unsafe SRS with degree `RECURSIVE_CIRCUIT_DEGREE`
     /// using [`Self::build_for_test_degree`].
     #[cfg(test)]
     pub(crate) fn build_for_test(
@@ -89,7 +89,7 @@ impl SnarkProverSetup {
         Self::build_for_test_degree(parameters, merkle_tree_depth, RECURSIVE_CIRCUIT_DEGREE)
     }
 
-    /// Builds an [`SnarkProverSetup`] from a deterministic unsafe SRS with degree determined by the input
+    /// Builds a [`SnarkProverSetup`] from a deterministic unsafe SRS with degree determined by the input
     /// `unsafe_srs_degree`.
     /// Uses a cache for the unsafe SRS to avoid regenerating it when a SRS of the correct degree already exists
     #[cfg(test)]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -185,7 +185,17 @@ impl IvcSnarkProverSetup {
         let parameters_bytes = parameters.to_bytes()?;
         let depth_bytes = merkle_tree_depth.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();
-        let cache = FileMutex::for_shared_cache(
+
+        // The unsafe SRS depends only on its degree and seed, never on the circuit parameters, so it
+        // is cached independently of them and shared by every parameter set that needs the same degree
+        // (`TrustedSetupProvider::with_unsafe_srs` itself nests its file by degree under this directory).
+        let srs_cache = FileMutex::for_shared_cache("unsafe-srs", &[&seed_bytes]);
+        let srs_directory = srs_cache.directory().to_path_buf();
+        let _srs_cache_lock = srs_cache.lock()?;
+        let trusted_setup_provider =
+            TrustedSetupProvider::with_unsafe_srs(&srs_directory, unsafe_srs_degree);
+
+        let key_cache = FileMutex::for_shared_cache(
             "ivc-setup",
             &[
                 NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
@@ -195,12 +205,10 @@ impl IvcSnarkProverSetup {
                 &seed_bytes,
             ],
         );
-        let cache_directory = cache.directory().to_path_buf();
+        let cache_directory = key_cache.directory().to_path_buf();
         // Serialize cold-start keygen across the parallel slow-test processes.
-        let _key_cache_lock = cache.lock()?;
+        let _key_cache_lock = key_cache.lock()?;
 
-        let trusted_setup_provider =
-            TrustedSetupProvider::with_unsafe_srs(&cache_directory, unsafe_srs_degree);
         let certificate_provider = KeyProvider::new(
             cache_directory.join("certificate"),
             "non-recursive",

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -156,9 +156,11 @@ impl IvcSnarkProverSetup {
 
     /// Builds an [`IvcSnarkProverSetup`] from a deterministic, oversized unsafe SRS, exercising the
     /// real `load` path without the production SRS. Shared by the slow IVC tests through a
-    /// content-keyed cache keyed by the protocol parameters, Merkle-tree depth, the unsafe SRS identity
-    /// (degree and seed), and the production verifying keys as a circuit-version salt, so the recursive
-    /// keys — the dominant cost — are computed once and reused across tests and runs.
+    /// content-keyed cache keyed by the protocol parameters, Merkle-tree depth, the unsafe SRS seed,
+    /// and the production verifying keys as a circuit-version salt — not the SRS degree, since `load`
+    /// always downsizes to `RECURSIVE_CIRCUIT_DEGREE` before deriving keys, so any `unsafe_srs_degree`
+    /// reproduces the same recursive keys — the dominant cost — letting calls at different degrees
+    /// share one already-computed key cache instead of each paying for keygen separately.
     #[cfg(test)]
     pub(crate) fn build_for_test(
         parameters: &crate::Parameters,
@@ -182,7 +184,6 @@ impl IvcSnarkProverSetup {
     ) -> StmResult<Self> {
         let parameters_bytes = parameters.to_bytes()?;
         let depth_bytes = merkle_tree_depth.to_le_bytes();
-        let degree_bytes = unsafe_srs_degree.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();
         let cache = FileMutex::for_shared_cache(
             "ivc-setup",
@@ -191,7 +192,6 @@ impl IvcSnarkProverSetup {
                 RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
                 &parameters_bytes,
                 &depth_bytes,
-                &degree_bytes,
                 &seed_bytes,
             ],
         );

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -7,13 +7,16 @@ use midnight_curves::{Bls12, G1Projective};
 use midnight_proofs::poly::kzg::{msm::DualMSM, params::ParamsKZG};
 
 #[cfg(test)]
-use crate::circuits::{
-    halo2::{
-        NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::StmCertificateCircuit,
+use crate::{
+    Parameters,
+    circuits::{
+        halo2::{
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::StmCertificateCircuit,
+        },
+        halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        test_utils::file_mutex::FileMutex,
+        trusted_setup::UNSAFE_SRS_SEED,
     },
-    halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-    test_utils::file_mutex::FileMutex,
-    trusted_setup::UNSAFE_SRS_SEED,
 };
 use crate::{
     StmResult,
@@ -154,31 +157,23 @@ impl IvcSnarkProverSetup {
         Ok(accumulator)
     }
 
-    /// Builds an [`IvcSnarkProverSetup`] from a deterministic, oversized unsafe SRS, exercising the
-    /// real `load` path without the production SRS. Shared by the slow IVC tests through a
-    /// content-keyed cache keyed by the protocol parameters, Merkle-tree depth, the unsafe SRS seed,
-    /// and the production verifying keys as a circuit-version salt — not the SRS degree, since `load`
-    /// always downsizes to `RECURSIVE_CIRCUIT_DEGREE` before deriving keys, so any `unsafe_srs_degree`
-    /// reproduces the same recursive keys — the dominant cost — letting calls at different degrees
-    /// share one already-computed key cache instead of each paying for keygen separately.
+    /// Builds an [`IvcSnarkProverSetup`] from a deterministic unsafe SRS with degree `RECURSIVE_CIRCUIT_DEGREE`
+    /// using [`Self::build_for_test_degree`].
     #[cfg(test)]
     pub(crate) fn build_for_test(
-        parameters: &crate::Parameters,
+        parameters: &Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Self> {
-        Self::build_for_test_with_unsafe_srs_degree(
-            parameters,
-            merkle_tree_depth,
-            RECURSIVE_CIRCUIT_DEGREE,
-        )
+        Self::build_for_test_degree(parameters, merkle_tree_depth, RECURSIVE_CIRCUIT_DEGREE)
     }
 
-    /// As [`Self::build_for_test`], but generates the unsafe SRS at `unsafe_srs_degree` instead of
-    /// exactly [`RECURSIVE_CIRCUIT_DEGREE`].  This removes the need to downsize in [`Self::load`] if
-    /// the input degree matches the circuit one.
+    /// Builds an [`IvcSnarkProverSetup`] from a deterministic unsafe SRS with degree determined by the input
+    /// `unsafe_srs_degree`.
+    /// Uses a cache for the unsafe SRS to avoid regenerating it when a SRS of the correct degree already exists
+    /// and also uses a separate cache for the circuit keys
     #[cfg(test)]
-    pub(crate) fn build_for_test_with_unsafe_srs_degree(
-        parameters: &crate::Parameters,
+    pub(crate) fn build_for_test_degree(
+        parameters: &Parameters,
         merkle_tree_depth: u32,
         unsafe_srs_degree: u32,
     ) -> StmResult<Self> {
@@ -186,9 +181,6 @@ impl IvcSnarkProverSetup {
         let depth_bytes = merkle_tree_depth.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();
 
-        // The unsafe SRS depends only on its degree and seed, never on the circuit parameters, so it
-        // is cached independently of them and shared by every parameter set that needs the same degree
-        // (`TrustedSetupProvider::with_unsafe_srs` itself nests its file by degree under this directory).
         let srs_cache = FileMutex::for_shared_cache("unsafe-srs", &[&seed_bytes]);
         let srs_directory = srs_cache.directory().to_path_buf();
         let _srs_cache_lock = srs_cache.lock()?;
@@ -288,7 +280,7 @@ mod tests {
                 phi_f: 0.2,
             };
             let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
-            let ivc_setup = IvcSnarkProverSetup::build_for_test_with_unsafe_srs_degree(
+            let ivc_setup = IvcSnarkProverSetup::build_for_test_degree(
                 &parameters,
                 merkle_tree_depth,
                 RECURSIVE_CIRCUIT_DEGREE + 1,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -177,6 +177,7 @@ impl IvcSnarkProverSetup {
         merkle_tree_depth: u32,
         unsafe_srs_degree: u32,
     ) -> StmResult<Self> {
+        assert!(unsafe_srs_degree >= RECURSIVE_CIRCUIT_DEGREE);
         let parameters_bytes = parameters.to_bytes()?;
         let depth_bytes = merkle_tree_depth.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -164,9 +164,25 @@ impl IvcSnarkProverSetup {
         parameters: &crate::Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Self> {
+        Self::build_for_test_with_unsafe_srs_degree(
+            parameters,
+            merkle_tree_depth,
+            RECURSIVE_CIRCUIT_DEGREE,
+        )
+    }
+
+    /// As [`Self::build_for_test`], but generates the unsafe SRS at `unsafe_srs_degree` instead of
+    /// exactly [`RECURSIVE_CIRCUIT_DEGREE`].  This removes the need to downsize in [`Self::load`] if
+    /// the input degree matches the circuit one.
+    #[cfg(test)]
+    pub(crate) fn build_for_test_with_unsafe_srs_degree(
+        parameters: &crate::Parameters,
+        merkle_tree_depth: u32,
+        unsafe_srs_degree: u32,
+    ) -> StmResult<Self> {
         let parameters_bytes = parameters.to_bytes()?;
         let depth_bytes = merkle_tree_depth.to_le_bytes();
-        let degree_bytes = (RECURSIVE_CIRCUIT_DEGREE + 1).to_le_bytes();
+        let degree_bytes = unsafe_srs_degree.to_le_bytes();
         let seed_bytes = UNSAFE_SRS_SEED.to_le_bytes();
         let cache = FileMutex::for_shared_cache(
             "ivc-setup",
@@ -184,7 +200,7 @@ impl IvcSnarkProverSetup {
         let _key_cache_lock = cache.lock()?;
 
         let trusted_setup_provider =
-            TrustedSetupProvider::with_unsafe_srs(&cache_directory, RECURSIVE_CIRCUIT_DEGREE + 1);
+            TrustedSetupProvider::with_unsafe_srs(&cache_directory, unsafe_srs_degree);
         let certificate_provider = KeyProvider::new(
             cache_directory.join("certificate"),
             "non-recursive",
@@ -264,8 +280,12 @@ mod tests {
                 phi_f: 0.2,
             };
             let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
-            let ivc_setup = IvcSnarkProverSetup::build_for_test(&parameters, merkle_tree_depth)
-                .expect("IvcSnarkProverSetup::load should succeed");
+            let ivc_setup = IvcSnarkProverSetup::build_for_test_with_unsafe_srs_degree(
+                &parameters,
+                merkle_tree_depth,
+                RECURSIVE_CIRCUIT_DEGREE + 1,
+            )
+            .expect("IvcSnarkProverSetup::load should succeed");
 
             let verification_context = load_embedded_verification_context_asset()
                 .expect("verification context asset should load");

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -361,16 +361,12 @@ mod tests {
         params: Parameters,
         depth: u32,
     ) -> (Arc<IvcSnarkProverSetup>, NonRecursiveCircuitVerifyingKey) {
-        let srs: Arc<ParamsKZG<Bls12>> = Arc::new(ParamsKZG::<Bls12>::unsafe_setup(
-            12,
-            ChaCha20Rng::from_seed([42u8; 32]),
-        ));
         let circuit = StmCertificateCircuit::try_new(&params, depth)
             .expect("certificate circuit should build");
         let circuit_degree = MidnightCircuit::from_relation(&circuit, None).k();
 
-        let mut cert_srs = (*srs).clone();
-        cert_srs.downsize(circuit_degree);
+        let cert_srs =
+            ParamsKZG::<Bls12>::unsafe_setup(circuit_degree, ChaCha20Rng::from_seed([42u8; 32]));
 
         let midnight_vk = zk::setup_vk(&cert_srs, &circuit);
         let midnight_pk = zk::setup_pk(&circuit, &midnight_vk);


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes an update to the way we use the unsafe SNARK setup in tests in order to reduce the runtime of the tests.

## Changes

- Reuse existing unsafe SRS files on disk instead of regenerating them each run.
- Stop unconditionally downsizing test SRS when it already matches the circuit's degree, avoiding a needless FFT.
- Split `build_for_test` into a fast default (exact degree) and an explicit oversized variant, for both `SnarkProverSetup` and `IvcSnarkProverSetup`.
- Drop SRS degree from the IVC key-cache fingerprint, since derived keys don't depend on it. This lets tests at different degrees share one key cache.
- Cache the unsafe SRS by degree and seed only, shared across all parameter sets instead of duplicated per test.

## Gain in test time
| Change | Duration | Run |
|---|---|---|
| Baseline (nightly 30/07) | 1h11m47s | [link](https://github.com/IntersectMBO/mithril/actions/runs/30506077425/job/90756011560) |
| `with_unsafe_srs` saves/loads an existing SRS file instead of regenerating it | 1h00m56s | [link](https://github.com/IntersectMBO/mithril/actions/runs/30538872179/job/90858636858) |
| Removed `downsize` from test code | 40m50s | [link](https://github.com/IntersectMBO/mithril/actions/runs/30552401815/job/90904114168?pr=3443) |
| Shared the cache across degree and parameters | 34m49s | [link](https://github.com/IntersectMBO/mithril/actions/runs/30643293824/job/91198342959?pr=3443) |

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3433 