### PR TITLE
refactor(stm): combine pairing checks ivc verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.4", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.5", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.5 (08-05-2026)
+
+### Changed
+
+- Updated the `verify` function of `IvcProof` to combine its two pairing checks into one. The MSMs are combined by drawing a random scalar from the transcript and using it to scale the accumulator values.
+
 ## 0.12.3 (08-05-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.4"
+version = "0.12.5"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
@@ -12,13 +12,9 @@ pub(crate) enum IvcProofError {
     #[error("IVC proof rejected: transcript was not fully consumed")]
     TranscriptNotFullyConsumed,
 
-    /// KZG opening equations (dual MSM check) did not verify.
-    #[error("IVC proof rejected: KZG opening check failed")]
-    KzgOpeningFailed,
-
-    /// Folded accumulator pairing equation did not verify.
-    #[error("IVC proof rejected: accumulator pairing check failed")]
-    AccumulatorFailed,
+    /// Combined accumulator and dual MSM pairing equation did not verify.
+    #[error("IVC proof rejected: combined accumulator and dual MSM pairing check failed")]
+    MsmCheckFailed,
 
     /// The PLONK prover (`create_proof`) failed internally.
     #[error("IVC proof generation failed: {0}")]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
@@ -14,7 +14,7 @@ pub(crate) enum IvcProofError {
 
     /// Combined accumulator and dual MSM pairing equation did not verify.
     #[error("IVC proof rejected: combined accumulator and dual MSM pairing check failed")]
-    MsmCheckFailed,
+    MsmPairingCheckFailed,
 
     /// The PLONK prover (`create_proof`) failed internally.
     #[error("IVC proof generation failed: {0}")]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -165,7 +165,7 @@ where
     ///
     /// `global` and `verifier_setup` must be built from the same certificate and IVC verifying
     /// keys. If they differ, the public inputs fed to the KZG opening check will not match the
-    /// proof transcript and verification will return [`IvcProofError::MsmCheckFailed`].
+    /// proof transcript and verification will return [`IvcProofError::MsmPairingCheckFailed`].
     pub(crate) fn verify(
         &self,
         msg: &[u8],
@@ -193,15 +193,20 @@ where
             .assert_empty()
             .map_err(|_| IvcProofError::TranscriptNotFullyConsumed)?;
 
-        // Fold the accumulator's own pairing check into `dual_msm` so verification pays for one
-        // pairing instead of two. `r` must be unpredictable to the prover before both `dual_msm`
-        // and `self.accumulator` are fixed; reusing this transcript gives that for free, since its
-        // state already absorbed `self.accumulator`'s public input (above) and the entire proof —
-        // no extra hashing or point encoding needed beyond squeezing one more challenge.
-        let r: CircuitBase = transcript.squeeze_challenge();
-
         let accumulator_lhs = self.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
         let accumulator_rhs = self.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
+
+        // `r` must depend both `dual_msm` and `self.accumulator` to make sure the combination can't be manipulated.
+        // The transcript should already absorb the dual_msm and accumulator but we make it explicit here
+        // in case the midnight library changes this in the future.
+        let (dual_msm_left_terms, dual_msm_right_terms) = dual_msm.split();
+        for (_, scalar, base) in dual_msm_left_terms.into_iter().chain(dual_msm_right_terms) {
+            transcript.common(scalar)?;
+            transcript.common(base)?;
+        }
+        transcript.common(&accumulator_lhs)?;
+        transcript.common(&accumulator_rhs)?;
+        let r: CircuitBase = transcript.squeeze_challenge();
 
         let mut accumulator_dual_msm = DualMSM::new(
             MSMKZG::from_base(&accumulator_lhs),
@@ -209,11 +214,11 @@ where
         );
         accumulator_dual_msm.scale(r);
 
-        let mut combined = dual_msm.clone(); // kept for the diagnostic fallback below
+        let mut combined = dual_msm;
         combined.add_msm(accumulator_dual_msm);
 
         if !combined.check(verifier_setup.verifier_params()) {
-            return Err(IvcProofError::MsmCheckFailed.into());
+            return Err(IvcProofError::MsmPairingCheckFailed.into());
         }
         Ok(())
     }
@@ -468,9 +473,21 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
 #[cfg(test)]
 mod tests {
 
-    use midnight_proofs::transcript::Blake2b256;
+    use ff::Field;
+    use group::Group;
+    use midnight_circuits::{types::Instantiable, verifier::AssignedAccumulator};
+    use midnight_curves::{Bls12, G1Projective};
+    use midnight_proofs::{
+        plonk::prepare,
+        poly::kzg::{
+            KZGCommitmentScheme,
+            msm::{DualMSM, MSMKZG},
+        },
+        transcript::{Blake2b256, CircuitTranscript, Transcript},
+    };
 
     use crate::{
+        circuits::halo2::types::CircuitBase,
         circuits::halo2_ivc::{
             state::Global,
             tests::common::{
@@ -679,7 +696,7 @@ mod tests {
             .expect_err("tampered proof bytes should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "tampered bytes must fail the KZG opening check, got: {err}"
         );
     }
@@ -730,7 +747,7 @@ mod tests {
             .expect_err("different protocol message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "different protocol message must fail the KZG opening check, got: {err}"
         );
     }
@@ -757,7 +774,7 @@ mod tests {
             .expect_err("state from a different proof should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "mismatched state corrupts public inputs and must fail the KZG opening check, got: {err}"
         );
     }
@@ -784,7 +801,7 @@ mod tests {
         );
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "mismatched accumulator corrupts public inputs and must fail the KZG opening check, got: {err}"
         );
     }
@@ -809,7 +826,7 @@ mod tests {
             .expect_err("Poseidon proof bytes should be rejected by IvcProof::<Blake2b>::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "Poseidon bytes via Blake2b path must fail the KZG opening check, got: {err}"
         );
     }
@@ -853,9 +870,68 @@ mod tests {
 
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::MsmCheckFailed),
+            Some(&IvcProofError::MsmPairingCheckFailed),
             "wrong fixed bases must fail the accumulator check (not the KZG check), got: {err}"
         );
+    }
+
+    #[test]
+    fn ivc_proof_verify_combined_check_holds_for_any_scalar_r() {
+        let (global, verifier_setup) = build_proof_verifier_context();
+        let step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+        let proof = IvcProof::<Blake2b256>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let public_inputs: Vec<CircuitBase> = [
+            global.as_public_input(),
+            proof.state.as_public_input(),
+            AssignedAccumulator::as_public_input(&proof.accumulator),
+        ]
+        .concat();
+
+        let mut transcript =
+            CircuitTranscript::<Blake2b256>::init_from_bytes(proof.proof_bytes.as_bytes());
+        let dual_msm =
+            prepare::<CircuitBase, KZGCommitmentScheme<Bls12>, CircuitTranscript<Blake2b256>>(
+                verifier_setup.ivc_verifying_key().verifying_key(),
+                &[&[G1Projective::identity()]],
+                &[&[&public_inputs]],
+                &mut transcript,
+            )
+            .expect("prepare should succeed for a valid proof");
+        transcript
+            .assert_empty()
+            .expect("transcript should be fully consumed");
+
+        let accumulator_lhs = proof.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
+        let accumulator_rhs = proof.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
+
+        let candidate_rs = [
+            CircuitBase::ONE,
+            CircuitBase::from(2u64),
+            CircuitBase::from(123_456_789u64),
+            -CircuitBase::ONE,
+        ];
+
+        for r in candidate_rs {
+            let mut accumulator_dual_msm = DualMSM::new(
+                MSMKZG::from_base(&accumulator_lhs),
+                MSMKZG::from_base(&accumulator_rhs),
+            );
+            accumulator_dual_msm.scale(r);
+
+            let mut combined = dual_msm.clone();
+            combined.add_msm(accumulator_dual_msm);
+
+            assert!(
+                combined.check(verifier_setup.verifier_params()),
+                "combined check must hold for a valid proof regardless of the combiner r={r:?}"
+            );
+        }
     }
 
     // The context guard is the first thing `IvcProver::prove` runs. It is tested directly here

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -155,24 +155,13 @@ where
     <KZGCommitmentScheme<Bls12> as PolynomialCommitmentScheme<CircuitBase>>::Commitment:
         Hashable<H>,
 {
-    /// Verifies the IVC proof and its folded accumulator using transcript hash `H`.
-    ///
-    /// Checks:
-    /// 1. The KZG opening equations against the IVC verifying key.
-    /// 2. The folded accumulator pairing equation.
-    ///
-    /// # Invariant
-    ///
-    /// `global` and `verifier_setup` must be built from the same certificate and IVC verifying
-    /// keys. If they differ, the public inputs fed to the KZG opening check will not match the
-    /// proof transcript and verification will return [`IvcProofError::MsmPairingCheckFailed`].
-    pub(crate) fn verify(
+    /// Prepares the KZG opening MSM and derives the Fiat-Shamir combiner `r` used to fold the
+    /// accumulator's pairing check into it.
+    pub(crate) fn prepare_combined_check(
         &self,
-        msg: &[u8],
         global: &Global,
         verifier_setup: &IvcVerifierSetup,
-    ) -> StmResult<()> {
-        self.check_input_message_matches_state_message(msg)?;
+    ) -> StmResult<(DualMSM<Bls12>, G1Projective, G1Projective, CircuitBase)> {
         let public_inputs: Vec<CircuitBase> = [
             global.as_public_input(),
             self.state.as_public_input(),
@@ -196,7 +185,7 @@ where
         let accumulator_lhs = self.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
         let accumulator_rhs = self.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
 
-        // `r` must depend both `dual_msm` and `self.accumulator` to make sure the combination can't be manipulated.
+        // `r` must depend on both `dual_msm` and `self.accumulator` to make sure the combination can't be manipulated.
         // The transcript should already absorb the dual_msm and accumulator but we make it explicit here
         // in case the midnight library changes this in the future.
         let (dual_msm_left_terms, dual_msm_right_terms) = dual_msm.split();
@@ -207,6 +196,29 @@ where
         transcript.common(&accumulator_lhs)?;
         transcript.common(&accumulator_rhs)?;
         let r: CircuitBase = transcript.squeeze_challenge();
+
+        Ok((dual_msm, accumulator_lhs, accumulator_rhs, r))
+    }
+
+    /// Verifies the IVC proof and its folded accumulator using transcript hash `H` by
+    /// combining both value as MSMs using a random scalar `r` and performing one
+    /// pairing check.
+    ///
+    /// # Invariant
+    ///
+    /// `global` and `verifier_setup` must be built from the same certificate and IVC verifying
+    /// keys used to produce this proof. If they differ, the combined pairing check will fail and
+    /// verification will return [`IvcProofError::MsmPairingCheckFailed`].
+    pub(crate) fn verify(
+        &self,
+        msg: &[u8],
+        global: &Global,
+        verifier_setup: &IvcVerifierSetup,
+    ) -> StmResult<()> {
+        self.check_input_message_matches_state_message(msg)?;
+
+        let (dual_msm, accumulator_lhs, accumulator_rhs, r) =
+            self.prepare_combined_check(global, verifier_setup)?;
 
         let mut accumulator_dual_msm = DualMSM::new(
             MSMKZG::from_base(&accumulator_lhs),
@@ -474,16 +486,9 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
 mod tests {
 
     use ff::Field;
-    use group::Group;
-    use midnight_circuits::{types::Instantiable, verifier::AssignedAccumulator};
-    use midnight_curves::{Bls12, G1Projective};
     use midnight_proofs::{
-        plonk::prepare,
-        poly::kzg::{
-            KZGCommitmentScheme,
-            msm::{DualMSM, MSMKZG},
-        },
-        transcript::{Blake2b256, CircuitTranscript, Transcript},
+        poly::kzg::msm::{DualMSM, MSMKZG},
+        transcript::Blake2b256,
     };
 
     use crate::{
@@ -541,8 +546,8 @@ mod tests {
     #[test]
     fn ivc_proof_verify_accepts_stored_recursive_step_output() {
         // Exercises the `IvcProof::verify` high-level API end-to-end against the
-        // stored next-epoch Blake2b proof, confirming that the unified verification
-        // path (KZG opening + accumulator pairing) accepts a known-good proof.
+        // stored next-epoch Blake2b proof, confirming that the combined pairing check
+        // accepts a known-good proof.
         let verification_context = load_embedded_verification_context_asset()
             .expect("verification context asset should load");
         let step_output = load_embedded_next_epoch_step_output_asset()
@@ -668,15 +673,15 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::InvalidMessage),
-            "tampered message must fail the KZG opening check, got: {err}"
+            "tampered message must fail message verification in IvcProof::verify, got: {err}"
         );
     }
 
     #[test]
     fn ivc_proof_verify_rejects_tampered_proof_bytes() {
-        // A single flipped byte anywhere in the proof transcript must cause `verify` to
-        // return `Err`: the KZG opening equations are computed over the raw bytes, so
-        // any corruption propagates to a bad MSM and the `dual_msm.check` fails.
+        // A single flipped byte anywhere in the proof transcript corrupts the raw bytes
+        // `dual_msm` is built from, so its side of the combined pairing equation no longer
+        // holds and `verify` returns `Err`.
         let (global, verifier_setup) = build_proof_verifier_context();
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
@@ -697,7 +702,7 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "tampered bytes must fail the KZG opening check, got: {err}"
+            "tampered bytes must fail the combined pairing check, got: {err}"
         );
     }
 
@@ -721,7 +726,7 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::InvalidMessage),
-            "different protocol message must fail the KZG opening check, got: {err}"
+            "different protocol message must fail message verification in IvcProof::verify, got: {err}"
         );
     }
 
@@ -748,15 +753,15 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "different protocol message must fail the KZG opening check, got: {err}"
+            "different protocol message must fail the combined pairing check, got: {err}"
         );
     }
 
     #[test]
     fn ivc_proof_verify_rejects_mismatched_state() {
         // Substituting the state from a different proof step changes the public inputs
-        // fed to `prepare`, causing `dual_msm.check` to fail against the unmodified
-        // proof bytes.
+        // fed to `prepare`, so `dual_msm`'s side of the combined equation no longer matches
+        // the unmodified proof bytes.
         let (global, verifier_setup) = build_proof_verifier_context();
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
@@ -775,7 +780,7 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "mismatched state corrupts public inputs and must fail the KZG opening check, got: {err}"
+            "mismatched state corrupts public inputs and must fail the combined pairing check, got: {err}"
         );
     }
 
@@ -783,7 +788,7 @@ mod tests {
     fn ivc_proof_verify_rejects_mismatched_accumulator() {
         // Substituting the accumulator from a different proof step corrupts the public
         // inputs fed to `prepare` (the accumulator is serialised into them), so
-        // `dual_msm.check` fails before the pairing equation is ever reached.
+        // `dual_msm`'s side of the combined equation no longer matches.
         let (global, verifier_setup) = build_proof_verifier_context();
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
@@ -802,7 +807,7 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "mismatched accumulator corrupts public inputs and must fail the KZG opening check, got: {err}"
+            "mismatched accumulator corrupts public inputs and must fail the combined pairing check, got: {err}"
         );
     }
 
@@ -827,15 +832,15 @@ mod tests {
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "Poseidon bytes via Blake2b path must fail the KZG opening check, got: {err}"
+            "Poseidon bytes via Blake2b path must fail the combined pairing check, got: {err}"
         );
     }
 
     #[test]
     fn ivc_proof_verify_rejects_wrong_fixed_bases() {
-        // A verifier setup with a wrong fixed bases but otherwise correct parameters passes
-        // the KZG opening check and fails at the accumulator pairing equation,
-        // exercising the AccumulatorFailed path.
+        // A verifier setup with wrong fixed bases but otherwise correct parameters leaves
+        // `dual_msm`'s side of the combined equation valid but corrupts the accumulator's
+        // side, so `combined.check` still fails.
         let ctx = load_embedded_verification_context_asset()
             .expect("verification context asset should load");
         let step_output = load_embedded_next_epoch_step_output_asset()
@@ -846,7 +851,8 @@ mod tests {
             &ctx.certificate_verifying_key,
             &ctx.recursive_verifying_key,
         );
-        // negate every fixed base: KZG opening check still passes, accumulator pairing breaks
+        // negate every fixed base: dual_msm's side of the equation still holds, only the
+        // accumulator's doesn't
         let wrong_fixed_bases = ctx
             .combined_fixed_bases
             .into_iter()
@@ -866,12 +872,12 @@ mod tests {
 
         let err = proof
             .verify(&STEP_OUTPUT_MSG, &global, &verifier_setup)
-            .expect_err("wrong fixed bases should cause the accumulator pairing check to fail");
+            .expect_err("wrong fixed bases should cause the combined pairing check to fail");
 
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::MsmPairingCheckFailed),
-            "wrong fixed bases must fail the accumulator check (not the KZG check), got: {err}"
+            "wrong fixed bases must fail the combined pairing check, got: {err}"
         );
     }
 
@@ -886,29 +892,9 @@ mod tests {
             step_output.next_accumulator,
         );
 
-        let public_inputs: Vec<CircuitBase> = [
-            global.as_public_input(),
-            proof.state.as_public_input(),
-            AssignedAccumulator::as_public_input(&proof.accumulator),
-        ]
-        .concat();
-
-        let mut transcript =
-            CircuitTranscript::<Blake2b256>::init_from_bytes(proof.proof_bytes.as_bytes());
-        let dual_msm =
-            prepare::<CircuitBase, KZGCommitmentScheme<Bls12>, CircuitTranscript<Blake2b256>>(
-                verifier_setup.ivc_verifying_key().verifying_key(),
-                &[&[G1Projective::identity()]],
-                &[&[&public_inputs]],
-                &mut transcript,
-            )
-            .expect("prepare should succeed for a valid proof");
-        transcript
-            .assert_empty()
-            .expect("transcript should be fully consumed");
-
-        let accumulator_lhs = proof.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
-        let accumulator_rhs = proof.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
+        let (dual_msm, accumulator_lhs, accumulator_rhs, _) = proof
+            .prepare_combined_check(&global, &verifier_setup)
+            .expect("prepare_combined_check should succeed for a valid proof");
 
         let candidate_rs = [
             CircuitBase::ONE,
@@ -1524,6 +1510,36 @@ mod tests {
             run_rejects_mismatched_avk_path(&ctx);
             run_rejects_corrupted_previous_ivc_proof_path(&ctx);
             run_rejects_mismatched_global_path(&ctx);
+        }
+    }
+
+    mod golden {
+        use super::*;
+
+        const GOLDEN_R: [u8; 32] = [
+            167, 66, 11, 195, 134, 213, 22, 97, 36, 22, 169, 16, 222, 26, 110, 27, 81, 13, 53, 172,
+            191, 68, 90, 117, 248, 154, 30, 122, 198, 17, 214, 30,
+        ];
+
+        #[test]
+        fn golden_combiner_r_for_stored_recursive_step_output() {
+            // Pins the exact Fiat-Shamir combiner r for a fixed, known-good proof.
+            // This test can fail if the assets are updated or if the dependency of
+            // r on the dual_msm and accumulator is changed.
+            let (global, verifier_setup) = build_proof_verifier_context();
+            let step_output = load_embedded_next_epoch_step_output_asset()
+                .expect("recursive step output asset should load");
+            let proof = IvcProof::<Blake2b256>::new(
+                step_output.ivc_proof,
+                step_output.next_state,
+                step_output.next_accumulator,
+            );
+
+            let (_, _, _, r) = proof
+                .prepare_combined_check(&global, &verifier_setup)
+                .expect("prepare_combined_check should succeed for a valid proof");
+
+            assert_eq!(r.to_bytes_le(), GOLDEN_R);
         }
     }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -15,7 +15,11 @@ use midnight_proofs::{
     plonk::{create_proof, prepare},
     poly::{
         commitment::PolynomialCommitmentScheme,
-        kzg::{KZGCommitmentScheme, params::ParamsKZG},
+        kzg::{
+            KZGCommitmentScheme,
+            msm::{DualMSM, MSMKZG},
+            params::ParamsKZG,
+        },
     },
     transcript::{Blake2b256, CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
 };
@@ -161,7 +165,7 @@ where
     ///
     /// `global` and `verifier_setup` must be built from the same certificate and IVC verifying
     /// keys. If they differ, the public inputs fed to the KZG opening check will not match the
-    /// proof transcript and verification will return [`IvcProofError::KzgOpeningFailed`].
+    /// proof transcript and verification will return [`IvcProofError::MsmCheckFailed`].
     pub(crate) fn verify(
         &self,
         msg: &[u8],
@@ -185,22 +189,32 @@ where
             &mut transcript,
         )
         .map_err(|_| IvcProofError::TranscriptPreparationFailed)?;
-
         transcript
             .assert_empty()
             .map_err(|_| IvcProofError::TranscriptNotFullyConsumed)?;
 
-        if !dual_msm.check(verifier_setup.verifier_params()) {
-            return Err(IvcProofError::KzgOpeningFailed.into());
-        }
+        // Fold the accumulator's own pairing check into `dual_msm` so verification pays for one
+        // pairing instead of two. `r` must be unpredictable to the prover before both `dual_msm`
+        // and `self.accumulator` are fixed; reusing this transcript gives that for free, since its
+        // state already absorbed `self.accumulator`'s public input (above) and the entire proof —
+        // no extra hashing or point encoding needed beyond squeezing one more challenge.
+        let r: CircuitBase = transcript.squeeze_challenge();
 
-        if !self.accumulator.check(
-            verifier_setup.verifier_params(),
-            verifier_setup.combined_fixed_bases(),
-        ) {
-            return Err(IvcProofError::AccumulatorFailed.into());
-        }
+        let accumulator_lhs = self.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
+        let accumulator_rhs = self.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
 
+        let mut accumulator_dual_msm = DualMSM::new(
+            MSMKZG::from_base(&accumulator_lhs),
+            MSMKZG::from_base(&accumulator_rhs),
+        );
+        accumulator_dual_msm.scale(r);
+
+        let mut combined = dual_msm.clone(); // kept for the diagnostic fallback below
+        combined.add_msm(accumulator_dual_msm);
+
+        if !combined.check(verifier_setup.verifier_params()) {
+            return Err(IvcProofError::MsmCheckFailed.into());
+        }
         Ok(())
     }
 
@@ -665,7 +679,7 @@ mod tests {
             .expect_err("tampered proof bytes should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "tampered bytes must fail the KZG opening check, got: {err}"
         );
     }
@@ -716,7 +730,7 @@ mod tests {
             .expect_err("different protocol message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "different protocol message must fail the KZG opening check, got: {err}"
         );
     }
@@ -743,7 +757,7 @@ mod tests {
             .expect_err("state from a different proof should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "mismatched state corrupts public inputs and must fail the KZG opening check, got: {err}"
         );
     }
@@ -770,7 +784,7 @@ mod tests {
         );
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "mismatched accumulator corrupts public inputs and must fail the KZG opening check, got: {err}"
         );
     }
@@ -795,7 +809,7 @@ mod tests {
             .expect_err("Poseidon proof bytes should be rejected by IvcProof::<Blake2b>::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "Poseidon bytes via Blake2b path must fail the KZG opening check, got: {err}"
         );
     }
@@ -839,7 +853,7 @@ mod tests {
 
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::AccumulatorFailed),
+            Some(&IvcProofError::MsmCheckFailed),
             "wrong fixed bases must fail the accumulator check (not the KZG check), got: {err}"
         );
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -37,11 +37,11 @@ use crate::{
 /// The certificate and IVC verifying keys used to build this struct must match those used to
 /// build the [`Global`] passed to [`IvcProof::verify`]. A mismatch silently produces wrong
 /// public inputs and will cause verification to fail with
-/// [`IvcProofError::KzgOpeningFailed`].
+/// [`IvcProofError::MsmPairingCheckFailed`].
 ///
 /// [`Global`]: crate::circuits::halo2_ivc::state::Global
 /// [`IvcProof::verify`]: crate::proof_system::ivc_halo2_snark::proof::IvcProof::verify
-/// [`IvcProofError::KzgOpeningFailed`]: crate::proof_system::ivc_halo2_snark::errors::IvcProofError::KzgOpeningFailed
+/// [`IvcProofError::MsmPairingCheckFailed`]: crate::proof_system::ivc_halo2_snark::errors::IvcProofError::MsmPairingCheckFailed
 pub(crate) struct IvcVerifierSetup {
     /// Stabilized KZG verifier parameters (embedded constant, no SRS load required).
     verifier_params: ParamsVerifierKZG<Bls12>,


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes an update to the verification function of the recursive proof to combine the two pairing checks (dual MSM and accumulator) into one to speed up the verification.

## Changes

- Convert the accumulator into an MSM 
- Select a random scalar `r` to combine as: combined_msm = dual_msm + r * acc_msm
- Perform one pairing check instead of two
- Keep one pairing check in case of failure to identify the source of the failure and return the correct error

## Measured gain

- with separated: 7.266ms
- with combined: 6.682ms
- Gain: ~8%

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced


## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3420 
