### PR TITLE
feat(common): updated the ed25519 dalek crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1547,9 +1554,26 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "group",
  "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1798,7 +1822,7 @@ checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "elliptic-curve",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -1810,7 +1834,17 @@ checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
  "serde",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "serdect",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1819,11 +1853,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1852,7 +1901,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -2047,6 +2096,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -3433,7 +3488,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -3465,7 +3520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb27d940b150ff718b407f94ff443915c4bbf938cc813b0164c827b170738fc"
 dependencies = [
  "blake2 0.9.2",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "rand_core 0.5.1",
  "serde",
  "serde_with 2.3.3",
@@ -3664,7 +3719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "multihash",
  "prost",
@@ -4063,7 +4118,7 @@ dependencies = [
  "bitvec",
  "blst",
  "byte-slice-cast",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "digest 0.10.7",
  "ff",
  "getrandom 0.2.17",
@@ -4527,8 +4582,9 @@ dependencies = [
  "ciborium",
  "criterion",
  "digest 0.10.7",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "fixed",
+ "getrandom 0.4.3",
  "hex",
  "kes-summed-ed25519",
  "mithril-build-script",
@@ -4536,6 +4592,7 @@ dependencies = [
  "mithril-stm",
  "mockall",
  "nom 8.0.0",
+ "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
@@ -6087,6 +6144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6663,7 +6730,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der",
  "generic-array",
  "pkcs8",
@@ -6894,6 +6961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7015,6 +7092,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7165,7 +7251,7 @@ dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
@@ -8659,7 +8745,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,14 +46,16 @@ blake2 = "0.10.6"
 chrono = { workspace = true }
 ciborium = { workspace = true }
 digest = { workspace = true }
-ed25519-dalek = { version = "2.2.0", features = ["rand_core", "serde"] }
+ed25519-dalek = { version = "3.0.0", features = ["rand_core", "serde"] }
 fixed = "1.31.0"
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
 mithril-stm = { path = "../mithril-stm", version = "0.12.5", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
+rand_chacha_ed25519 = { package = "rand_chacha", version = "0.10.0" }
 rand_core = { workspace = true }
 rayon = { workspace = true }
 semver = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/cold_key.rs
+++ b/mithril-common/src/crypto_helper/cardano/cold_key.rs
@@ -1,6 +1,5 @@
 use ed25519_dalek::SigningKey as ColdSecretKey;
-use rand_chacha::ChaCha20Rng;
-use rand_core::SeedableRng;
+use rand_chacha_ed25519::{ChaCha20Rng, rand_core::SeedableRng};
 
 /// A cold key generator / test only
 #[doc(hidden)]

--- a/mithril-common/src/crypto_helper/ed25519.rs
+++ b/mithril-common/src/crypto_helper/ed25519.rs
@@ -50,6 +50,16 @@ impl Ed25519Signer {
 
     /// [Ed25519Signer] non deterministic
     pub fn create_non_deterministic_signer() -> Self {
+        // `rand_core`'s `OsRng` was removed and replaced by `getrandom::SysRng`. `OsRng` was
+        // a wrapper around `getrandom` internally so the functionality does not change.
+        // `SysRng` reads from the same OS entropy sources as before (e.g. the `getrandom`
+        // syscall on Linux, `ProcessPrng` on Windows, `getentropy` on macOS) under
+        // the same documented security guarantee.
+        //
+        // `SysRng` only implements the fallible `TryRng`/`TryCryptoRng` (an OS entropy call can,
+        // in principle, fail). `UnwrapErr` makes `SysRng` Infallible to fit the `generate` bounds.
+        // It can panic on failure in the same way `OsRng` did so the chance of failure stays the
+        // same.
         let rng = UnwrapErr(SysRng);
         Self::create_test_signer(rng)
     }

--- a/mithril-common/src/crypto_helper/ed25519.rs
+++ b/mithril-common/src/crypto_helper/ed25519.rs
@@ -1,9 +1,10 @@
 //! Ed25519 cryptographic helpers
 
 use anyhow::anyhow;
+use ed25519_dalek::rand_core::{CryptoRng, UnwrapErr};
 use ed25519_dalek::{Signer, SigningKey};
-use rand_chacha::ChaCha20Rng;
-use rand_chacha::rand_core::{CryptoRng, RngCore, SeedableRng};
+use getrandom::SysRng;
+use rand_chacha_ed25519::{ChaCha20Rng, rand_core::SeedableRng};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -35,7 +36,7 @@ impl Ed25519Signer {
     /// [Ed25519Signer] factory
     pub fn create_test_signer<R>(mut rng: R) -> Self
     where
-        R: CryptoRng + RngCore,
+        R: CryptoRng,
     {
         let secret_key = SigningKey::generate(&mut rng);
         Self::from_secret_key(secret_key.into())
@@ -49,7 +50,7 @@ impl Ed25519Signer {
 
     /// [Ed25519Signer] non deterministic
     pub fn create_non_deterministic_signer() -> Self {
-        let rng = rand_core::OsRng;
+        let rng = UnwrapErr(SysRng);
         Self::create_test_signer(rng)
     }
 


### PR DESCRIPTION

## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes an update of the ed25519 dalek crate from 2.2.0 to 3.0.0. It also includes a bridge to link two incompatible version of `rand_core`.

## Changes

- Update the `ed25519-dalek` crate from ` 2.2.0` to `3.0.0`
- Add a renamed version of the `rand_chacha` crate to fix the deterministic RNG
- Import the `genrandom` crate directly to replace the removed `OsRng` of `rand_core` with `SysRng` (the new version of `ed25519-dalek` requires a new `rand_core` that does not have the `OsRng` anymore
- Use a wrapper `UnwrapErr` around the `SysRng` to make it `Infallible`

## Details on the change of OS RNG

To fit with the new crate versions and dependencies, we need to move from `rand_core::OsRng` to `getrandom::SysRng`. This does not change the entropy source or security posture: `OsRng` was already a wrapper around `getrandom` internally, and `rand_core` 0.10.1 removed `OsRng` in favor of exposing that same `getrandom`-backed source directly as `SysRng`. 
Both read from the same OS-level entropy sources (the `getrandom` syscall on Linux, `ProcessPrng` on Windows, `getentropy` on macOS, etc.) under the same documented security guarantee. The one visible difference is that `SysRng` only implements the fallible `TryRng`/`TryCryptoRng` traits, since an OS entropy call can in principle fail, whereas `ed25519-dalek`'s `generate()` requires an infallible RNG. The wrapper `rand_core::UnwrapErr` takes care of this by implementing the `TryRng` trait with and `Infallible` error.  It still panics on an OS failure in the same way OsRng already did internally, so the practical chance of hitting it is unchanged.


## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3471 
