### PR TITLE
fix(e2e): fix flakiness with minimal scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.10"
+version = "0.5.11"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -284,7 +284,7 @@ impl MithrilInfrastructure {
             AggregateSignatureType::Concatenation => ProtocolParameters {
                 k: 70,
                 m: 105,
-                phi_f: 0.95,
+                phi_f: 0.77,
             },
             AggregateSignatureType::Snark | AggregateSignatureType::IvcSnark => {
                 ProtocolParameters {


### PR DESCRIPTION
## Content

This PR includes a **fix for the flakiness of the e2e test in `minimal` mode, where certificates could be sealed with an incomplete signer set**.

The new protocol parameters are crafted to avoid having one signer reach the quorum alone which lead to the `Certificate is not signed by expected number of signers: 1 < 2` error. The success rate witnessed on my local environment increased from 75% to 100% with the new protocol parameters.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3452
