### PR TITLE
fix(e2e): strengthen concatenation protocol parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.11"
+version = "0.5.12"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -282,8 +282,8 @@ impl MithrilInfrastructure {
 
         let protocol_parameters_new = match config.aggregate_signature_type {
             AggregateSignatureType::Concatenation => ProtocolParameters {
-                k: 70,
-                m: 105,
+                k: 274,
+                m: 420,
                 phi_f: 0.77,
             },
             AggregateSignatureType::Snark | AggregateSignatureType::IvcSnark => {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
@@ -102,9 +102,9 @@ impl ExecToolkit {
         aggregator.stop().await?;
         let protocol_parameters_new = match aggregate_signature_type {
             AggregateSignatureType::Concatenation => ProtocolParameters {
-                k: 83,
-                m: 130,
-                phi_f: 0.75,
+                k: 283,
+                m: 433,
+                phi_f: 0.77,
             },
             AggregateSignatureType::Snark => ProtocolParameters {
                 k: 7,


### PR DESCRIPTION
## Content

This PR includes a **strengthening of the Concatenation protocol parameters used by the e2e tests to remove a lottery-induced flakiness in the CI**.

- Fix the root cause of the `Timeout exhausted waiting for Certificate` failures: with `k=70, m=105, phi_f=0.77`, the two signers together cover fewer than `k` lottery indexes in ~1 draw out of 177, and when this happens on the first open message of an epoch the aggregator ends the epoch without any certificate and blocks with an unrecoverable epoch gap.
- Scale the initial parameter set from `k=70, m=105, phi_f=0.77` to `k=274, m=420, phi_f=0.77`.
- Scale the updated parameter set (applied at the protocol parameters change phase) from `k=83, m=130, phi_f=0.75` to `k=283, m=433, phi_f=0.77`.
- Both sets keep the all-signers-required property (no single signer can reach the quorum alone).

### Benchmark on CI
| Scenario | [Attempt 1](https://github.com/IntersectMBO/mithril/actions/runs/31179678944/attempts/1) | [Attempt 2](https://github.com/IntersectMBO/mithril/actions/runs/31179678944) | Successes | Failures | Success rate |
|---|---|---|---|---|---|
| Full (120 std + 7 special modes) | 127/127 | 127/127 | 254 | 0 | 100% |
| Minimal (120 std) | 120/120 | 120/120 | 240 | 0 | 100% |
| **Total** | 247/247 | 247/247 | **494** | **0** | **100%** |

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3452
