### PR TITLE
feat(stm): add missing off circuit checks

### DIFF
--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.10 (08-26-2026)
+
+### Added
+
+- Added more off-circuit checks: validation of the protocol message hash, check of the validity of the genesis verification key, check that the protocol parameters do not evolve from one epoch to the next, ensuring the new accumulator is correctly created.
+- Placed off-circuit checks before proof creation when possible to avoid unnecessary heavy computations.
+
 ## 0.12.9 (08-26-2026)
 
 ### Changed

--- a/mithril-stm/src/circuits/halo2_ivc/bench/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/bench/helpers.rs
@@ -221,7 +221,7 @@ impl IvcBenchEnv {
             genesis_fixture.genesis_verification_key,
             &setup.certificate_verifying_key,
             &setup.ivc_verifying_key,
-        );
+        )?;
 
         Ok(Self {
             setup,

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -52,6 +52,12 @@ pub enum IvcCircuitError {
     /// Off-circuit accumulator check: the msm does not match the provided the fixed bases
     #[error("Fixed base `{name}` in the dual MSM does not match the provided map")]
     MsmFixedBasesNamesMismatch { name: String },
+
+    /// Off-circuit step transition: `SHA256(protocol_message_preimage)`, reduced into the
+    /// base field the same way the circuit's `assert_message_matches_preimage` constraint
+    /// does, does not match the message the proof would otherwise commit to.
+    #[error("IvcProverInput::prepare: message preimage does not hash to the expected message")]
+    MessagePreimageMismatch,
 }
 
 /// Subcategorization for `IvcCircuitError::InvalidEpochTransition`. Lets negative

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -54,10 +54,15 @@ pub enum IvcCircuitError {
     MsmFixedBasesNamesMismatch { name: String },
 
     /// Off-circuit step transition: `SHA256(protocol_message_preimage)`, reduced into the
-    /// base field the same way the circuit's `assert_message_matches_preimage` constraint
-    /// does, does not match the message the proof would otherwise commit to.
+    /// base field, does not match the message the proof would otherwise commit to.
     #[error("IvcProverInput::prepare: message preimage does not hash to the expected message")]
     MessagePreimageMismatch,
+
+    /// Off-circuit rolling-state check: the chain's carried `protocol_parameters` and its
+    /// declared `next_protocol_parameters` have diverged past the genesis-to-first-step
+    /// transition.
+    #[error("IvcRollingState: protocol_parameters and next_protocol_parameters have diverged")]
+    ProtocolParametersChanged,
 }
 
 /// Subcategorization for `IvcCircuitError::InvalidEpochTransition`. Lets negative

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::StmResult;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
@@ -115,14 +116,15 @@ pub(crate) struct Global {
 }
 
 impl Global {
-    #[allow(dead_code)]
     pub(crate) fn new(
         genesis_message: MessageHash,
         genesis_verification_key: SchnorrVerificationKey,
         certificate_verification_key: &NonRecursiveCircuitVerifyingKey,
         ivc_verification_key: &RecursiveCircuitVerifyingKey,
-    ) -> Self {
-        Global {
+    ) -> StmResult<Self> {
+        genesis_verification_key.is_valid()?;
+
+        Ok(Global {
             genesis_message,
             genesis_verification_key,
             certificate_circuit_verification_key_representation:
@@ -133,7 +135,7 @@ impl Global {
                 IvcCircuitVerificationKeyRepresentation::from_field(
                     ivc_verification_key.as_ref().transcript_repr(),
                 ),
-        }
+        })
     }
 
     pub(crate) fn as_public_input(&self) -> Vec<NativeField> {

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -201,3 +201,42 @@ pub(crate) struct AssignedWitness {
     // Protocol message preimage bytes
     pub(crate) message_preimage: Vec<AssignedByte<NativeField>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        circuits::{
+            halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        },
+        codec::TryFromBytes,
+        signature_scheme::SchnorrSignatureError,
+    };
+
+    use super::*;
+
+    #[test]
+    fn new_rejects_invalid_genesis_verification_key() {
+        let certificate_verifying_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .expect("production certificate verifying key bytes should deserialize");
+        let ivc_verifying_key = RecursiveCircuitVerifyingKey::try_from_bytes(
+            RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .expect("production IVC verifying key bytes should deserialize");
+
+        let err = Global::new(
+            MessageHash::ZERO,
+            SchnorrVerificationKey::default(),
+            &certificate_verifying_key,
+            &ivc_verifying_key,
+        )
+        .expect_err("Global::new should reject an invalid genesis verification key");
+
+        assert!(matches!(
+            err.downcast_ref::<SchnorrSignatureError>(),
+            Some(SchnorrSignatureError::PointIsNotPrimeOrder(..))
+        ));
+    }
+}

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -471,6 +471,7 @@ pub(crate) fn build_recursive_global(
         certificate_verifying_key,
         recursive_verifying_key,
     )
+    .expect("test fixture genesis verification key must be valid")
 }
 
 /// Value committed by the genesis message as the next protocol parameters.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
@@ -34,4 +34,10 @@ pub(crate) enum IvcProofError {
         "IVC proof rejected: the message used to create the proof is different from the input message"
     )]
     InvalidMessage,
+
+    /// New accumulator created from the previous ivc proof and new certificate proof does not verify
+    #[error(
+        "IVC proof rejected: New accumulator created from the previous ivc proof and new certificate proof does not verify"
+    )]
+    InvalidNextAccumulator,
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
@@ -8,4 +8,6 @@ pub(crate) mod verifier_setup;
 
 #[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_input::IvcProverInput;
+pub(crate) use prover_input::PreparedIvcSnarkRequest;
+#[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_setup::IvcSnarkProverSetup;

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -43,7 +43,10 @@ use crate::{
     proof_system::ivc_halo2_snark::{
         errors::IvcProofError,
         prover_input::IvcProverInput,
-        prover_input_helpers::IvcTransitionType,
+        prover_input_helpers::{
+            IvcTransitionType, assert_message_hash_matches_preimage,
+            create_snark_message_for_next_state,
+        },
         prover_setup::IvcSnarkProverSetup,
         rolling_state::{IvcRollingState, midnight_accumulator_serde},
         verifier_setup::IvcVerifierSetup,
@@ -59,16 +62,16 @@ pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
     pub(crate) rng: R,
 }
 
-/// Runs [`IvcProverInput::prepare_checks`] and discards the result. Exposed so a caller like
+/// Runs [`IvcProverInput::off_circuit_checks`] and discards the result. Exposed so a caller like
 /// `Clerk::aggregate_signatures_with_type` can reject a malformed request before generating the
 /// certificate proof, without needing access to `IvcProverInput` itself.
-pub(crate) fn prepare_checks<D: MembershipDigest>(
+pub(crate) fn off_circuit_checks<D: MembershipDigest>(
     message: &[u8],
     aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
     protocol_message_preimage: &ProtocolMessagePreimage,
     rolling_state: &IvcRollingState,
 ) -> StmResult<()> {
-    IvcProverInput::prepare_checks(
+    IvcProverInput::off_circuit_checks(
         message,
         aggregate_verification_key,
         protocol_message_preimage,
@@ -78,16 +81,24 @@ pub(crate) fn prepare_checks<D: MembershipDigest>(
 }
 
 /// Runs [`IvcProverInput::prepare_genesis`]'s checks and discards the result: verifies the
-/// genesis message hashes to the supplied preimage, then verifies the genesis Schnorr
-/// signature. Exposed so a caller like `Clerk::aggregate_signatures_with_type` can reject a
-/// malformed genesis request before generating the certificate proof.
-pub(crate) fn prepare_genesis_checks(
+/// genesis message hashes to `genesis_protocol_message_preimage`, then verifies the genesis
+/// Schnorr signature. Additionally checks that the first real certificate's own message hashes
+/// to `protocol_message_preimage`, mirroring [`off_circuit_checks`]'s hash check for the
+/// non-genesis path. Exposed so a caller like `Clerk::aggregate_signatures_with_type` can reject
+/// a malformed genesis request before generating the certificate proof.
+pub(crate) fn off_circuit_genesis_checks<D: MembershipDigest>(
     rolling_state: &IvcRollingState,
-    protocol_message_preimage: &ProtocolMessagePreimage,
+    genesis_protocol_message_preimage: &ProtocolMessagePreimage,
     global: &Global,
+    message: &[u8],
+    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+    protocol_message_preimage: &ProtocolMessagePreimage,
 ) -> StmResult<()> {
-    IvcProverInput::prepare_genesis(rolling_state, protocol_message_preimage, global)?;
-    Ok(())
+    IvcProverInput::prepare_genesis(rolling_state, genesis_protocol_message_preimage, global)?;
+
+    let (certificate_message_hash, _) =
+        create_snark_message_for_next_state(aggregate_verification_key, message)?;
+    assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)
 }
 
 /// Bootstrap input for the first [`IvcProver::prove`] call in an IVC chain.
@@ -338,7 +349,9 @@ where
 /// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
 /// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
 /// both-`None` misuses are now unrepresentable.
-fn ensure_advanceable_rolling_state(rolling_state: Option<&IvcRollingState>) -> StmResult<()> {
+pub(crate) fn ensure_advanceable_rolling_state(
+    rolling_state: Option<&IvcRollingState>,
+) -> StmResult<()> {
     if rolling_state.is_some_and(|rs| rs.is_genesis()) {
         return Err(IvcProofError::InvalidProvingContext.into());
     }
@@ -523,24 +536,34 @@ mod tests {
     };
 
     use crate::{
+        AggregateVerificationKeyForSnark, MithrilMembershipDigest,
         circuits::halo2::types::CircuitBase,
         circuits::halo2_ivc::{
+            PREIMAGE_SIZE,
+            errors::IvcCircuitError,
             state::Global,
             tests::common::{
                 asset_readers::{
+                    load_embedded_first_certificate_in_epoch_asset,
                     load_embedded_following_certificate_in_epoch_asset,
                     load_embedded_next_epoch_step_output_asset,
                     load_embedded_recursive_chain_state_asset,
                     load_embedded_verification_context_asset,
                 },
-                generators::{build_asset_generation_setup_from_cache, build_recursive_global},
+                generators::{
+                    build_asset_generation_setup_from_cache,
+                    build_genesis_protocol_message_preimage, build_recursive_global,
+                    setup::TOTAL_STAKE,
+                },
             },
-            types::{IvcProofBytes, MessageHash},
+            types::{IvcProofBytes, MessageHash, ProtocolMessagePreimage},
         },
-        proof_system::ivc_halo2_snark::{errors::IvcProofError, verifier_setup::IvcVerifierSetup},
+        proof_system::ivc_halo2_snark::{
+            errors::IvcProofError, rolling_state::IvcRollingState, verifier_setup::IvcVerifierSetup,
+        },
     };
 
-    use super::IvcProof;
+    use super::{IvcProof, off_circuit_genesis_checks};
 
     const STEP_OUTPUT_MSG: [u8; 32] = [
         22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
@@ -572,6 +595,76 @@ mod tests {
             ctx.combined_fixed_bases,
         );
         (global, verifier_setup)
+    }
+
+    /// Builds a valid genesis rolling state and preimage
+    fn build_consistent_genesis_fixture() -> (IvcRollingState, ProtocolMessagePreimage) {
+        let setup = build_asset_generation_setup_from_cache();
+        let genesis_protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
+            build_genesis_protocol_message_preimage(&setup)
+                .try_into()
+                .expect("genesis preimage should be exactly PREIMAGE_SIZE bytes");
+        let rolling_state = IvcRollingState::genesis(setup.genesis_signature, &[]);
+        (
+            rolling_state,
+            ProtocolMessagePreimage::new(genesis_protocol_message_preimage_bytes),
+        )
+    }
+
+    #[test]
+    fn off_circuit_genesis_checks_rejects_mismatched_certificate_preimage() {
+        let (global, _) = build_proof_verifier_context();
+        let (rolling_state, genesis_protocol_message_preimage) = build_consistent_genesis_fixture();
+
+        let avk =
+            AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&[0u8; 40])
+                .expect("zero AVK should decode");
+        let mismatched_preimage = ProtocolMessagePreimage::new([0u8; PREIMAGE_SIZE]);
+
+        let err = off_circuit_genesis_checks(
+            &rolling_state,
+            &genesis_protocol_message_preimage,
+            &global,
+            &[0u8; 32],
+            &avk,
+            &mismatched_preimage,
+        )
+        .expect_err("mismatched certificate preimage must be rejected");
+
+        let circuit_error = err
+            .downcast_ref::<IvcCircuitError>()
+            .expect("error chain should carry IvcCircuitError");
+        assert!(matches!(
+            circuit_error,
+            IvcCircuitError::MessagePreimageMismatch
+        ));
+    }
+
+    #[test]
+    fn off_circuit_genesis_checks_accepts_matching_certificate_preimage() {
+        let (global, _) = build_proof_verifier_context();
+        let (rolling_state, genesis_protocol_message_preimage) = build_consistent_genesis_fixture();
+
+        let first_step = load_embedded_first_certificate_in_epoch_asset()
+            .expect("first certificate asset should load");
+
+        let mut avk_bytes = [0u8; 40];
+        avk_bytes[0..32].copy_from_slice(&first_step.aggregate_verification_key_merkle_root);
+        avk_bytes[32..40].copy_from_slice(&TOTAL_STAKE.to_be_bytes());
+        let avk =
+            AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_bytes)
+                .expect("AVK should decode from asset bytes");
+        let protocol_message_preimage = ProtocolMessagePreimage::new(first_step.message_preimage);
+
+        off_circuit_genesis_checks(
+            &rolling_state,
+            &genesis_protocol_message_preimage,
+            &global,
+            &first_step.message,
+            &avk,
+            &protocol_message_preimage,
+        )
+        .expect("matching certificate preimage should be accepted");
     }
 
     #[test]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -43,10 +43,7 @@ use crate::{
     proof_system::ivc_halo2_snark::{
         errors::IvcProofError,
         prover_input::IvcProverInput,
-        prover_input_helpers::{
-            IvcTransitionType, assert_message_hash_matches_preimage,
-            create_snark_message_for_next_state,
-        },
+        prover_input_helpers::IvcTransitionType,
         prover_setup::IvcSnarkProverSetup,
         rolling_state::{IvcRollingState, midnight_accumulator_serde},
         verifier_setup::IvcVerifierSetup,
@@ -60,45 +57,6 @@ pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
     pub(crate) ivc_setup: Arc<IvcSnarkProverSetup>,
     /// Randomness source used during proof generation.
     pub(crate) rng: R,
-}
-
-/// Runs [`IvcProverInput::off_circuit_checks`] and discards the result. Exposed so a caller like
-/// `Clerk::aggregate_signatures_with_type` can reject a malformed request before generating the
-/// certificate proof, without needing access to `IvcProverInput` itself.
-pub(crate) fn off_circuit_checks<D: MembershipDigest>(
-    message: &[u8],
-    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
-    protocol_message_preimage: &ProtocolMessagePreimage,
-    rolling_state: &IvcRollingState,
-) -> StmResult<()> {
-    IvcProverInput::off_circuit_checks(
-        message,
-        aggregate_verification_key,
-        protocol_message_preimage,
-        rolling_state,
-    )?;
-    Ok(())
-}
-
-/// Runs [`IvcProverInput::prepare_genesis`]'s checks and discards the result: verifies the
-/// genesis message hashes to `genesis_protocol_message_preimage`, then verifies the genesis
-/// Schnorr signature. Additionally checks that the first real certificate's own message hashes
-/// to `protocol_message_preimage`, mirroring [`off_circuit_checks`]'s hash check for the
-/// non-genesis path. Exposed so a caller like `Clerk::aggregate_signatures_with_type` can reject
-/// a malformed genesis request before generating the certificate proof.
-pub(crate) fn off_circuit_genesis_checks<D: MembershipDigest>(
-    rolling_state: &IvcRollingState,
-    genesis_protocol_message_preimage: &ProtocolMessagePreimage,
-    global: &Global,
-    message: &[u8],
-    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
-    protocol_message_preimage: &ProtocolMessagePreimage,
-) -> StmResult<()> {
-    IvcProverInput::prepare_genesis(rolling_state, genesis_protocol_message_preimage, global)?;
-
-    let (certificate_message_hash, _) =
-        create_snark_message_for_next_state(aggregate_verification_key, message)?;
-    assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)
 }
 
 /// Bootstrap input for the first [`IvcProver::prove`] call in an IVC chain.
@@ -563,7 +521,7 @@ mod tests {
         },
     };
 
-    use super::{IvcProof, off_circuit_genesis_checks};
+    use super::IvcProof;
 
     const STEP_OUTPUT_MSG: [u8; 32] = [
         22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
@@ -621,15 +579,15 @@ mod tests {
                 .expect("zero AVK should decode");
         let mismatched_preimage = ProtocolMessagePreimage::new([0u8; PREIMAGE_SIZE]);
 
-        let err = off_circuit_genesis_checks(
-            &rolling_state,
-            &genesis_protocol_message_preimage,
-            &global,
-            &[0u8; 32],
-            &avk,
-            &mismatched_preimage,
-        )
-        .expect_err("mismatched certificate preimage must be rejected");
+        let err = rolling_state
+            .off_circuit_genesis_checks(
+                &genesis_protocol_message_preimage,
+                &global,
+                &[0u8; 32],
+                &avk,
+                &mismatched_preimage,
+            )
+            .expect_err("mismatched certificate preimage must be rejected");
 
         let circuit_error = err
             .downcast_ref::<IvcCircuitError>()
@@ -656,15 +614,15 @@ mod tests {
                 .expect("AVK should decode from asset bytes");
         let protocol_message_preimage = ProtocolMessagePreimage::new(first_step.message_preimage);
 
-        off_circuit_genesis_checks(
-            &rolling_state,
-            &genesis_protocol_message_preimage,
-            &global,
-            &first_step.message,
-            &avk,
-            &protocol_message_preimage,
-        )
-        .expect("matching certificate preimage should be accepted");
+        rolling_state
+            .off_circuit_genesis_checks(
+                &genesis_protocol_message_preimage,
+                &global,
+                &first_step.message,
+                &avk,
+                &protocol_message_preimage,
+            )
+            .expect("matching certificate preimage should be accepted");
     }
 
     #[test]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -300,22 +300,6 @@ where
     }
 }
 
-/// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
-///
-/// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
-/// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
-/// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
-/// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
-/// both-`None` misuses are now unrepresentable.
-pub(crate) fn ensure_advanceable_rolling_state(
-    rolling_state: Option<&IvcRollingState>,
-) -> StmResult<()> {
-    if rolling_state.is_some_and(|rs| rs.is_genesis()) {
-        return Err(IvcProofError::InvalidProvingContext.into());
-    }
-    Ok(())
-}
-
 impl<R: RngCore + CryptoRng> IvcProver<R> {
     /// Advances the IVC chain by one step.
     ///
@@ -348,7 +332,7 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
         genesis_bootstrap: &IvcGenesisBootstrapInput,
         rolling_state: Option<&IvcRollingState>,
     ) -> StmResult<(IvcProof<Blake2b256>, Option<IvcRollingState>)> {
-        ensure_advanceable_rolling_state(rolling_state)?;
+        IvcRollingState::ensure_advanceable_rolling_state(rolling_state)?;
 
         // `rolling_state = None` is the first certificate: bootstrap from genesis internally,
         // then continue with the seeded state. Otherwise advance from the supplied state.
@@ -1017,8 +1001,6 @@ mod tests {
             signature_scheme::{BaseFieldElement, SchnorrSigningKey},
         };
 
-        use super::ensure_advanceable_rolling_state;
-
         // A genesis signature is needed to build any rolling state; its value is irrelevant
         // because the guard only inspects the step counter.
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
@@ -1028,12 +1010,13 @@ mod tests {
             .expect("genesis signature should be produced");
 
         // `None` bootstraps from genesis internally: accepted.
-        ensure_advanceable_rolling_state(None).expect("None must be accepted (genesis bootstrap)");
+        IvcRollingState::ensure_advanceable_rolling_state(None)
+            .expect("None must be accepted (genesis bootstrap)");
 
         // A genesis rolling state (`step_counter == 0`) must be rejected.
         let genesis_state = IvcRollingState::genesis(genesis_signature, &[]);
         assert!(genesis_state.is_genesis());
-        let err = ensure_advanceable_rolling_state(Some(&genesis_state))
+        let err = IvcRollingState::ensure_advanceable_rolling_state(Some(&genesis_state))
             .expect_err("genesis rolling state must be rejected");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -1051,7 +1034,7 @@ mod tests {
             chain_state.genesis_signature,
         );
         assert!(!advanced_state.is_genesis());
-        ensure_advanceable_rolling_state(Some(&advanced_state))
+        IvcRollingState::ensure_advanceable_rolling_state(Some(&advanced_state))
             .expect("a non-genesis rolling state must be accepted");
     }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -59,6 +59,37 @@ pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
     pub(crate) rng: R,
 }
 
+/// Runs [`IvcProverInput::prepare_checks`] and discards the result. Exposed so a caller like
+/// `Clerk::aggregate_signatures_with_type` can reject a malformed request before generating the
+/// certificate proof, without needing access to `IvcProverInput` itself.
+pub(crate) fn prepare_checks<D: MembershipDigest>(
+    message: &[u8],
+    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+    protocol_message_preimage: &ProtocolMessagePreimage,
+    rolling_state: &IvcRollingState,
+) -> StmResult<()> {
+    IvcProverInput::prepare_checks(
+        message,
+        aggregate_verification_key,
+        protocol_message_preimage,
+        rolling_state,
+    )?;
+    Ok(())
+}
+
+/// Runs [`IvcProverInput::prepare_genesis`]'s checks and discards the result: verifies the
+/// genesis message hashes to the supplied preimage, then verifies the genesis Schnorr
+/// signature. Exposed so a caller like `Clerk::aggregate_signatures_with_type` can reject a
+/// malformed genesis request before generating the certificate proof.
+pub(crate) fn prepare_genesis_checks(
+    rolling_state: &IvcRollingState,
+    protocol_message_preimage: &ProtocolMessagePreimage,
+    global: &Global,
+) -> StmResult<()> {
+    IvcProverInput::prepare_genesis(rolling_state, protocol_message_preimage, global)?;
+    Ok(())
+}
+
 /// Bootstrap input for the first [`IvcProver::prove`] call in an IVC chain.
 ///
 /// Always supplied to [`IvcProver::prove`] by reference; used only when `rolling_state = None`

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -15,8 +15,8 @@ use crate::{
     },
     proof_system::ivc_halo2_snark::{
         prover_input_helpers::{
-            IvcTransitionType, build_next_accumulator, build_next_state,
-            create_snark_message_for_next_state, verify_certificate_proof,
+            IvcTransitionType, assert_message_hash_matches_preimage, build_next_accumulator,
+            build_next_state, create_snark_message_for_next_state, verify_certificate_proof,
         },
         prover_setup::IvcSnarkProverSetup,
         rolling_state::IvcRollingState,
@@ -66,15 +66,17 @@ impl IvcProverInput {
             transition_type,
         )?;
 
+        let (certificate_message_hash, certificate_merkle_tree_commitment) =
+            create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
+
+        assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
+
         let certificate_dual_msm = verify_certificate_proof(
             certificate_proof,
             message,
             aggregate_verification_key_for_snark,
             prover_setup,
         )?;
-
-        let (certificate_message_hash, certificate_merkle_tree_commitment) =
-            create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
 
         let next_state = build_next_state(
             transition_type,
@@ -111,6 +113,8 @@ impl IvcProverInput {
         protocol_message_preimage: &ProtocolMessagePreimage,
         global: &Global,
     ) -> StmResult<Self> {
+        assert_message_hash_matches_preimage(global.genesis_message, protocol_message_preimage)?;
+
         rolling_state.verify_genesis_signature(global)?;
 
         let new_step_counter = rolling_state.new_step_counter()?;
@@ -278,8 +282,15 @@ mod test {
             let chain_verification_key =
                 SchnorrVerificationKey::new_from_signing_key(chain_signing_key);
 
+            let preimage_bytes = [0u8; PREIMAGE_SIZE];
+            let genesis_message = MessageHash::from_field(
+                BaseFieldElement::try_from(preimage_bytes.as_slice())
+                    .expect("hashing should not fail")
+                    .0,
+            );
+
             let global = Global {
-                genesis_message: MessageHash::ZERO,
+                genesis_message,
                 genesis_verification_key: chain_verification_key,
                 certificate_circuit_verification_key_representation:
                     CertificateCircuitVerificationKeyRepresentation::from_field(
@@ -300,7 +311,7 @@ mod test {
                 )
                 .expect("sign_standard should succeed for a synthetic message");
             let rolling_state = IvcRollingState::genesis(invalid_signature, &[]);
-            let protocol_message_preimage = ProtocolMessagePreimage::new([0u8; PREIMAGE_SIZE]);
+            let protocol_message_preimage = ProtocolMessagePreimage::new(preimage_bytes);
 
             let err = IvcProverInput::prepare_genesis(
                 &rolling_state,
@@ -324,9 +335,17 @@ mod test {
             let verification_key =
                 SchnorrVerificationKey::new_from_signing_key(signing_key.clone());
 
+            let cert_epoch = EpochNumber::ZERO;
+            let mut preimage_bytes = [0u8; PREIMAGE_SIZE];
+            preimage_bytes[PREIMAGE_CURRENT_EPOCH_BYTES]
+                .copy_from_slice(&cert_epoch.as_u64().to_le_bytes());
+            preimage_bytes[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].copy_from_slice(&[0x11; 32]);
+            preimage_bytes[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].copy_from_slice(&[0x22; 32]);
+            let protocol_message_preimage = ProtocolMessagePreimage::new(preimage_bytes);
+
             let genesis_message = MessageHash::from_field(
-                BaseFieldElement::from_raw(&[0x42; 32])
-                    .expect("from_raw applies modulus reduction")
+                BaseFieldElement::try_from(preimage_bytes.as_slice())
+                    .expect("hashing should not fail")
                     .0,
             );
             let global = Global {
@@ -349,14 +368,6 @@ mod test {
                 )
                 .expect("sign_standard should succeed for the genesis message");
             let rolling_state = IvcRollingState::genesis(genesis_signature, &[]);
-
-            let cert_epoch = EpochNumber::ZERO;
-            let mut preimage_bytes = [0u8; PREIMAGE_SIZE];
-            preimage_bytes[PREIMAGE_CURRENT_EPOCH_BYTES]
-                .copy_from_slice(&cert_epoch.as_u64().to_le_bytes());
-            preimage_bytes[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].copy_from_slice(&[0x11; 32]);
-            preimage_bytes[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].copy_from_slice(&[0x22; 32]);
-            let protocol_message_preimage = ProtocolMessagePreimage::new(preimage_bytes);
 
             let input = IvcProverInput::prepare_genesis(
                 &rolling_state,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -3,7 +3,12 @@
 //! Holds the witness, the advanced chain state, and the folded accumulator that
 //! the in-circuit construction and proof-generation steps consume next.
 
+#[cfg(feature = "future_snark")]
+use std::sync::Arc;
+
 use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
+#[cfg(feature = "future_snark")]
+use midnight_proofs::transcript::Blake2b256;
 
 use crate::{
     AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
@@ -20,6 +25,15 @@ use crate::{
         },
         prover_setup::IvcSnarkProverSetup,
         rolling_state::{IvcProverInputChecks, IvcRollingState},
+    },
+};
+#[cfg(feature = "future_snark")]
+use crate::{
+    AncillaryProofInput, AncillaryProverData, AncillaryVerifierData, SingleSignature,
+    circuits::halo2::keys::NonRecursiveCircuitVerifyingKey,
+    proof_system::{
+        SnarkClerk,
+        ivc_halo2_snark::proof::{IvcGenesisBootstrapInput, IvcProof},
     },
 };
 
@@ -193,6 +207,196 @@ impl IvcProverInput {
             next_accumulator: rolling_state.accumulator().clone(),
             transition_type: IvcTransitionType::Genesis,
         })
+    }
+}
+
+/// Bundles the outputs of [`prepare_and_check_ivc_snark_request`]: everything [`prove_ivc_snark`] needs to
+/// generate the certificate proof and complete IVC proving, once the request has passed every
+/// check that doesn't require that proof.
+#[cfg(feature = "future_snark")]
+pub(crate) struct PreparedIvcSnarkRequest<'a> {
+    ivc_prover_setup: Arc<IvcSnarkProverSetup>,
+    certificate_verifying_key: NonRecursiveCircuitVerifyingKey,
+    global: Global,
+    protocol_message_preimage: ProtocolMessagePreimage,
+    current_rolling_state: Option<&'a IvcRollingState>,
+    genesis_bootstrap: IvcGenesisBootstrapInput,
+}
+
+impl<'a> PreparedIvcSnarkRequest<'a> {
+    /// Loads the IVC prover setup, builds [`Global`], and runs every off circuit check that
+    /// doesn't require the certificate proof: genesis verification key validity, rolling-state
+    /// presence, protocol parameters unchanged, and message/preimage hash matching (genesis or
+    /// non-genesis, depending on whether `ancillary_input` carries a rolling state).
+    #[cfg(feature = "future_snark")]
+    pub(crate) fn prepare_and_check_ivc_snark_request(
+        snark_clerk: &SnarkClerk,
+        ancillary_input: &'a AncillaryProofInput,
+        msg: &[u8],
+    ) -> StmResult<Self> {
+        use anyhow::anyhow;
+
+        use crate::{
+            AggregationError, MERKLE_TREE_DEPTH_FOR_SNARK, MithrilMembershipDigest,
+            circuits::{
+                halo2_ivc::PREIMAGE_SIZE, key_provider::KeyProvider,
+                trusted_setup::TrustedSetupProvider,
+            },
+        };
+
+        let genesis_data = ancillary_input.genesis_data();
+        let genesis_verifying_key = genesis_data
+            .genesis_schnorr_verification_key()
+            .cloned()
+            .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
+        let genesis_message = genesis_data.genesis_message_preimage().try_into()?;
+        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+
+        let current_rolling_state = ancillary_input
+            .prover_data()
+            .map(|prover_data| {
+                prover_data.as_ivc_rolling_state().ok_or(anyhow!(
+                    AggregationError::MissingIvcRollingStateInAncillaryProverData
+                ))
+            })
+            .transpose()?;
+        IvcRollingState::ensure_advanceable_rolling_state(current_rolling_state)?;
+
+        let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
+            ancillary_input.message_preimage().try_into()?;
+        let protocol_message_preimage = ProtocolMessagePreimage(protocol_message_preimage_bytes);
+
+        let trusted_setup_provider = TrustedSetupProvider::default();
+        let certificate_provider = KeyProvider::for_non_recursive_circuit(
+            &snark_clerk.parameters,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )?;
+        let recursive_key_provider = KeyProvider::for_recursive_circuit(certificate_provider);
+        let ivc_prover_setup = Arc::new(IvcSnarkProverSetup::load(
+            &trusted_setup_provider,
+            &recursive_key_provider,
+        )?);
+        let certificate_verifying_key = ivc_prover_setup.certificate_verifying_key.clone();
+
+        let global = Global::new(
+            genesis_message,
+            genesis_verifying_key,
+            &certificate_verifying_key,
+            &ivc_prover_setup.ivc_verifying_key,
+        )?;
+
+        let avk =
+            snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+
+        match current_rolling_state {
+            Some(rolling_state) => {
+                rolling_state.assert_protocol_parameters_unchanged()?;
+                rolling_state.off_circuit_checks(msg, &avk, &protocol_message_preimage)?;
+            }
+            None => {
+                let combined_fixed_base_names: Vec<String> =
+                    ivc_prover_setup.combined_fixed_bases.keys().cloned().collect();
+                let genesis_rolling_state = IvcRollingState::genesis(
+                    genesis_bootstrap.genesis_signature,
+                    &combined_fixed_base_names,
+                );
+                genesis_rolling_state.off_circuit_genesis_checks(
+                    &genesis_bootstrap.genesis_protocol_message_preimage,
+                    &global,
+                    msg,
+                    &avk,
+                    &protocol_message_preimage,
+                )?;
+            }
+        }
+
+        Ok(PreparedIvcSnarkRequest {
+            ivc_prover_setup,
+            certificate_verifying_key,
+            global,
+            protocol_message_preimage,
+            current_rolling_state,
+            genesis_bootstrap,
+        })
+    }
+
+    /// Generates the certificate proof and completes IVC proving for a request already validated by
+    /// [`prepare_and_check_ivc_snark_request`].
+    ///
+    /// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
+    /// the step advances the epoch and `None` for same-epoch steps.
+    ///
+    /// # Errors
+    /// Fails if the message preimage is not PREIMAGE_SIZE bytes, or the proof itself fails.
+    #[cfg(feature = "future_snark")]
+    pub(crate) fn prove_ivc_snark(
+        self,
+        sigs: &[SingleSignature],
+        msg: &[u8],
+        snark_clerk: &SnarkClerk,
+    ) -> StmResult<(
+        IvcProof<Blake2b256>,
+        Option<AncillaryProverData>,
+        AncillaryVerifierData,
+    )> {
+        use anyhow::Context;
+        use rand_core::OsRng;
+
+        use crate::{
+            MERKLE_TREE_DEPTH_FOR_SNARK, MithrilMembershipDigest,
+            proof_system::{
+                SnarkProver,
+                ivc_halo2_snark::{proof::IvcProver, verifier_setup::IvcVerifierData},
+            },
+        };
+
+        let snark_proof = SnarkProver::try_new_non_deterministic(
+            &snark_clerk.parameters,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )?
+        .aggregate_signatures::<MithrilMembershipDigest>(snark_clerk, sigs, msg)
+        .with_context(|| {
+            use crate::AggregateSignatureType;
+
+            format!(
+                "Signatures failed to aggregate for type {}",
+                AggregateSignatureType::Snark
+            )
+        })?;
+
+        let avk =
+            snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+
+        let ivc_verifying_key = self.ivc_prover_setup.ivc_verifying_key.clone();
+
+        let mut prover = IvcProver {
+            ivc_setup: self.ivc_prover_setup,
+            rng: OsRng,
+        };
+
+        let (ivc_proof, next_rolling_state) = prover.prove(
+            snark_proof,
+            msg,
+            &avk,
+            &self.global,
+            &self.protocol_message_preimage,
+            &self.genesis_bootstrap,
+            self.current_rolling_state,
+        )?;
+
+        let next_ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
+
+        let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
+            self.global.genesis_message,
+            self.certificate_verifying_key,
+            ivc_verifying_key,
+        ));
+
+        Ok((
+            ivc_proof,
+            next_ancillary_prover_data,
+            ancillary_verifier_data,
+        ))
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -37,23 +37,24 @@ pub(crate) struct IvcProverInput {
     pub(crate) transition_type: IvcTransitionType,
 }
 
+/// Bundles [`IvcProverInput::prepare_checks`]'s outputs, carried into
+/// [`IvcProverInput::finish`] once the certificate proof is available.
+pub(crate) struct IvcProverInputChecks {
+    transition_type: IvcTransitionType,
+    certificate_message_hash: MessageHash,
+    certificate_merkle_tree_commitment: MerkleTreeCommitment,
+}
+
 impl IvcProverInput {
-    /// Advances the chain state by one step and bundles the in-circuit witness, the
-    /// next state, and the next folded accumulator.
-    ///
-    /// First classifies the requested step via [`IvcTransitionType::try_compute_transition_type`], then
-    /// validates the epoch advance against the rolling chain state.
-    /// The certificate proof is verifier-prepared, then the certificate and previous IVC accumulators are
-    /// folded into the chain's accumulator.
-    pub(crate) fn prepare<D: MembershipDigest>(
-        certificate_proof: &SnarkProof<D>,
+    /// Runs every `prepare` check that does not need the certificate proof: classifies the
+    /// step, validates the epoch advance and protocol-parameter lookahead against the rolling
+    /// state, and checks the message hashes to the supplied preimage.
+    pub(crate) fn prepare_checks<D: MembershipDigest>(
         message: &[u8],
         aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
-        global: &Global,
         protocol_message_preimage: &ProtocolMessagePreimage,
         rolling_state: &IvcRollingState,
-        prover_setup: &IvcSnarkProverSetup,
-    ) -> StmResult<Self> {
+    ) -> StmResult<IvcProverInputChecks> {
         let transition_type = IvcTransitionType::try_compute_transition_type(
             rolling_state,
             protocol_message_preimage,
@@ -70,6 +71,32 @@ impl IvcProverInput {
             create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
 
         assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
+
+        Ok(IvcProverInputChecks {
+            transition_type,
+            certificate_message_hash,
+            certificate_merkle_tree_commitment,
+        })
+    }
+
+    /// Completes `prepare` once the certificate proof is available: verifies it, advances the
+    /// chain state, and folds the accumulator. `checks` must come from [`Self::prepare_checks`]
+    /// run against the same `protocol_message_preimage` and `rolling_state`.
+    pub(crate) fn finish_prepare<D: MembershipDigest>(
+        checks: IvcProverInputChecks,
+        certificate_proof: &SnarkProof<D>,
+        message: &[u8],
+        aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
+        global: &Global,
+        protocol_message_preimage: &ProtocolMessagePreimage,
+        rolling_state: &IvcRollingState,
+        prover_setup: &IvcSnarkProverSetup,
+    ) -> StmResult<Self> {
+        let IvcProverInputChecks {
+            transition_type,
+            certificate_message_hash,
+            certificate_merkle_tree_commitment,
+        } = checks;
 
         let certificate_dual_msm = verify_certificate_proof(
             certificate_proof,
@@ -102,6 +129,40 @@ impl IvcProverInput {
             next_accumulator,
             transition_type,
         })
+    }
+
+    /// Advances the chain state by one step and bundles the in-circuit witness, the
+    /// next state, and the next folded accumulator.
+    ///
+    /// Runs [`Self::prepare_checks`] then [`Self::finish_prepare`]. Callers that want to reject a
+    /// malformed request before the certificate proof is generated should call
+    /// [`Self::prepare_checks`] directly, ahead of time, instead of using this combined form.
+    pub(crate) fn prepare<D: MembershipDigest>(
+        certificate_proof: &SnarkProof<D>,
+        message: &[u8],
+        aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
+        global: &Global,
+        protocol_message_preimage: &ProtocolMessagePreimage,
+        rolling_state: &IvcRollingState,
+        prover_setup: &IvcSnarkProverSetup,
+    ) -> StmResult<Self> {
+        let checks = Self::prepare_checks(
+            message,
+            aggregate_verification_key_for_snark,
+            protocol_message_preimage,
+            rolling_state,
+        )?;
+
+        Self::finish_prepare(
+            checks,
+            certificate_proof,
+            message,
+            aggregate_verification_key_for_snark,
+            global,
+            protocol_message_preimage,
+            rolling_state,
+            prover_setup,
+        )
     }
 
     /// Builds the genesis-step `IvcProverInput`. Verifies the chain's genesis signature,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -37,24 +37,26 @@ pub(crate) struct IvcProverInput {
     pub(crate) transition_type: IvcTransitionType,
 }
 
-/// Bundles [`IvcProverInput::prepare_checks`]'s outputs, carried into
-/// [`IvcProverInput::finish`] once the certificate proof is available.
-pub(crate) struct IvcProverInputChecks {
+/// Bundles [`IvcProverInput::off_circuit_checks`]'s outputs, carried into
+/// [`IvcProverInput::finish_preparation`] once the certificate proof is available.
+pub(crate) struct IvcProverInputChecks<D: MembershipDigest> {
     transition_type: IvcTransitionType,
     certificate_message_hash: MessageHash,
     certificate_merkle_tree_commitment: MerkleTreeCommitment,
+    message: Vec<u8>,
+    aggregate_verification_key_for_snark: AggregateVerificationKeyForSnark<D>,
 }
 
 impl IvcProverInput {
-    /// Runs every `prepare` check that does not need the certificate proof: classifies the
-    /// step, validates the epoch advance and protocol-parameter lookahead against the rolling
-    /// state, and checks the message hashes to the supplied preimage.
-    pub(crate) fn prepare_checks<D: MembershipDigest>(
+    /// Runs every `prepare` off circuit check that does not need the certificate proof:
+    /// classifies the step, validates the epoch advance and protocol-parameter lookahead
+    /// against the rolling state, and checks the message hashes to the supplied preimage.
+    pub(crate) fn off_circuit_checks<D: MembershipDigest>(
         message: &[u8],
         aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
         protocol_message_preimage: &ProtocolMessagePreimage,
         rolling_state: &IvcRollingState,
-    ) -> StmResult<IvcProverInputChecks> {
+    ) -> StmResult<IvcProverInputChecks<D>> {
         let transition_type = IvcTransitionType::try_compute_transition_type(
             rolling_state,
             protocol_message_preimage,
@@ -76,17 +78,17 @@ impl IvcProverInput {
             transition_type,
             certificate_message_hash,
             certificate_merkle_tree_commitment,
+            message: message.to_vec(),
+            aggregate_verification_key_for_snark: aggregate_verification_key_for_snark.clone(),
         })
     }
 
     /// Completes `prepare` once the certificate proof is available: verifies it, advances the
-    /// chain state, and folds the accumulator. `checks` must come from [`Self::prepare_checks`]
+    /// chain state, and folds the accumulator. `checks` must come from [`Self::off_circuit_checks`]
     /// run against the same `protocol_message_preimage` and `rolling_state`.
-    pub(crate) fn finish_prepare<D: MembershipDigest>(
-        checks: IvcProverInputChecks,
+    pub(crate) fn finish_preparation<D: MembershipDigest>(
+        checks: IvcProverInputChecks<D>,
         certificate_proof: &SnarkProof<D>,
-        message: &[u8],
-        aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
         global: &Global,
         protocol_message_preimage: &ProtocolMessagePreimage,
         rolling_state: &IvcRollingState,
@@ -96,12 +98,14 @@ impl IvcProverInput {
             transition_type,
             certificate_message_hash,
             certificate_merkle_tree_commitment,
+            message,
+            aggregate_verification_key_for_snark,
         } = checks;
 
         let certificate_dual_msm = verify_certificate_proof(
             certificate_proof,
-            message,
-            aggregate_verification_key_for_snark,
+            message.as_slice(),
+            &aggregate_verification_key_for_snark,
             prover_setup,
         )?;
 
@@ -134,9 +138,9 @@ impl IvcProverInput {
     /// Advances the chain state by one step and bundles the in-circuit witness, the
     /// next state, and the next folded accumulator.
     ///
-    /// Runs [`Self::prepare_checks`] then [`Self::finish_prepare`]. Callers that want to reject a
+    /// Runs [`Self::off_circuit_checks`] then [`Self::finish_preparation`]. Callers that want to reject a
     /// malformed request before the certificate proof is generated should call
-    /// [`Self::prepare_checks`] directly, ahead of time, instead of using this combined form.
+    /// [`Self::off_circuit_checks`] directly, ahead of time, instead of using this combined form.
     pub(crate) fn prepare<D: MembershipDigest>(
         certificate_proof: &SnarkProof<D>,
         message: &[u8],
@@ -146,18 +150,16 @@ impl IvcProverInput {
         rolling_state: &IvcRollingState,
         prover_setup: &IvcSnarkProverSetup,
     ) -> StmResult<Self> {
-        let checks = Self::prepare_checks(
+        let checks = Self::off_circuit_checks(
             message,
             aggregate_verification_key_for_snark,
             protocol_message_preimage,
             rolling_state,
         )?;
 
-        Self::finish_prepare(
+        Self::finish_preparation(
             checks,
             certificate_proof,
-            message,
-            aggregate_verification_key_for_snark,
             global,
             protocol_message_preimage,
             rolling_state,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -52,41 +52,6 @@ pub(crate) struct IvcProverInput {
 }
 
 impl IvcProverInput {
-    /// Runs every `prepare` off circuit check that does not need the certificate proof:
-    /// classifies the step, validates the epoch advance and protocol-parameter lookahead
-    /// against the rolling state, and checks the message hashes to the supplied preimage.
-    // pub(crate) fn off_circuit_checks<D: MembershipDigest>(
-    //     message: &[u8],
-    //     aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
-    //     protocol_message_preimage: &ProtocolMessagePreimage,
-    //     rolling_state: &IvcRollingState,
-    // ) -> StmResult<IvcProverInputChecks<D>> {
-    //     let transition_type = IvcTransitionType::try_compute_transition_type(
-    //         rolling_state,
-    //         protocol_message_preimage,
-    //     )?;
-
-    //     rolling_state.assert_correct_parameters(
-    //         protocol_message_preimage,
-    //         aggregate_verification_key_for_snark,
-    //         message,
-    //         transition_type,
-    //     )?;
-
-    //     let (certificate_message_hash, certificate_merkle_tree_commitment) =
-    //         create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
-
-    //     assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
-
-    //     Ok(IvcProverInputChecks {
-    //         transition_type,
-    //         certificate_message_hash,
-    //         certificate_merkle_tree_commitment,
-    //         message: message.to_vec(),
-    //         aggregate_verification_key_for_snark: aggregate_verification_key_for_snark.clone(),
-    //     })
-    // }
-
     /// Completes `prepare` once the certificate proof is available: verifies it, advances the
     /// chain state, and folds the accumulator. `checks` must come from [`Self::off_circuit_checks`]
     /// run against the same `protocol_message_preimage` and `rolling_state`.
@@ -417,7 +382,7 @@ mod test {
             circuits::halo2_ivc::{
                 PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
                 PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE,
-                errors::{EpochTransitionErrorKind, IvcCircuitError},
+                errors::IvcCircuitError,
                 io::Write as IvcWrite,
                 tests::common::{
                     asset_readers::{
@@ -831,8 +796,6 @@ mod test {
         fn prepare_rejects_invalid_genesis_signature() {
             let setup = shared_ivc_setup();
             let asset_setup = shared_asset_setup();
-            let first_step = load_embedded_first_certificate_in_epoch_asset()
-                .expect("first step cert asset should load");
 
             let global = build_global();
             let mut sig_bytes = asset_setup.genesis_signature.to_bytes();
@@ -843,19 +806,13 @@ mod test {
             let combined_names: Vec<String> = setup.combined_fixed_bases.keys().cloned().collect();
             let rolling_state = IvcRollingState::genesis(bad_signature, &combined_names);
 
-            let snark_proof = wrap_snark_proof(first_step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&first_step.aggregate_verification_key_merkle_root);
             let genesis_preimage_bytes = build_genesis_protocol_message_preimage(asset_setup);
             let protocol_message_preimage = wrap_protocol_message_preimage(&genesis_preimage_bytes);
 
-            let result = IvcProverInput::prepare(
-                &snark_proof,
-                &first_step.message,
-                &avk,
-                &global,
-                &protocol_message_preimage,
+            let result = IvcProverInput::prepare_genesis(
                 &rolling_state,
-                setup,
+                &protocol_message_preimage,
+                &global,
             );
 
             let err = result
@@ -865,112 +822,6 @@ mod test {
             assert!(
                 matches!(err, SchnorrSignatureError::StandardSignatureInvalid(_)),
                 "expected StandardSignatureInvalid, got {err:?}"
-            );
-        }
-
-        #[test]
-        #[ignore = "slow: runs real keygen via shared OnceLock; opt-in only"]
-        fn prepare_rejects_invalid_epoch_transition() {
-            let setup = shared_ivc_setup();
-            let chain_state = load_embedded_recursive_chain_state_asset()
-                .expect("recursive chain state asset should load");
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let modified_state = State::new(
-                chain_state.state.step_counter,
-                chain_state.state.message,
-                chain_state.state.merkle_tree_commitment,
-                chain_state.state.next_merkle_tree_commitment,
-                chain_state.state.protocol_parameters,
-                chain_state.state.next_protocol_parameters,
-                EpochNumber::new(u64::MAX - 100),
-            );
-            let rolling_state = build_rolling_state(
-                modified_state,
-                chain_state.ivc_proof,
-                chain_state.accumulator,
-                chain_state.genesis_signature,
-            );
-
-            let global = build_global();
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let result = IvcProverInput::prepare(
-                &snark_proof,
-                &step.message,
-                &avk,
-                &global,
-                &protocol_message_preimage,
-                &rolling_state,
-                setup,
-            );
-
-            let err = result
-                .expect_err("prepare should reject a bad epoch transition")
-                .downcast::<IvcCircuitError>()
-                .expect("error should downcast to IvcCircuitError");
-            assert!(
-                matches!(
-                    err,
-                    IvcCircuitError::InvalidEpochTransition {
-                        kind: EpochTransitionErrorKind::EpochGap { .. },
-                        ..
-                    }
-                ),
-                "expected InvalidEpochTransition with OutOfRange kind, got {err:?}"
-            );
-        }
-
-        #[test]
-        #[ignore = "slow: runs real keygen via shared OnceLock; opt-in only"]
-        fn prepare_rejects_step_counter_overflow() {
-            let setup = shared_ivc_setup();
-            let chain_state = load_embedded_recursive_chain_state_asset()
-                .expect("recursive chain state asset should load");
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let modified_state = State::new(
-                StepCounter::new(u64::MAX),
-                chain_state.state.message,
-                chain_state.state.merkle_tree_commitment,
-                chain_state.state.next_merkle_tree_commitment,
-                chain_state.state.protocol_parameters,
-                chain_state.state.next_protocol_parameters,
-                chain_state.state.current_epoch,
-            );
-            let rolling_state = build_rolling_state(
-                modified_state,
-                chain_state.ivc_proof,
-                chain_state.accumulator,
-                chain_state.genesis_signature,
-            );
-
-            let global = build_global();
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let result = IvcProverInput::prepare(
-                &snark_proof,
-                &step.message,
-                &avk,
-                &global,
-                &protocol_message_preimage,
-                &rolling_state,
-                setup,
-            );
-
-            let err = result
-                .expect_err("prepare should reject step counter overflow")
-                .downcast::<IvcCircuitError>()
-                .expect("error should downcast to IvcCircuitError");
-            assert!(
-                matches!(err, IvcCircuitError::StepCounterOverflow { .. }),
-                "expected StepCounterOverflow, got {err:?}"
             );
         }
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -16,10 +16,10 @@ use crate::{
     proof_system::ivc_halo2_snark::{
         prover_input_helpers::{
             IvcTransitionType, assert_message_hash_matches_preimage, build_next_accumulator,
-            build_next_state, create_snark_message_for_next_state, verify_certificate_proof,
+            build_next_state, verify_certificate_proof,
         },
         prover_setup::IvcSnarkProverSetup,
-        rolling_state::IvcRollingState,
+        rolling_state::{IvcProverInputChecks, IvcRollingState},
     },
 };
 
@@ -37,51 +37,41 @@ pub(crate) struct IvcProverInput {
     pub(crate) transition_type: IvcTransitionType,
 }
 
-/// Bundles [`IvcProverInput::off_circuit_checks`]'s outputs, carried into
-/// [`IvcProverInput::finish_preparation`] once the certificate proof is available.
-pub(crate) struct IvcProverInputChecks<D: MembershipDigest> {
-    transition_type: IvcTransitionType,
-    certificate_message_hash: MessageHash,
-    certificate_merkle_tree_commitment: MerkleTreeCommitment,
-    message: Vec<u8>,
-    aggregate_verification_key_for_snark: AggregateVerificationKeyForSnark<D>,
-}
-
 impl IvcProverInput {
     /// Runs every `prepare` off circuit check that does not need the certificate proof:
     /// classifies the step, validates the epoch advance and protocol-parameter lookahead
     /// against the rolling state, and checks the message hashes to the supplied preimage.
-    pub(crate) fn off_circuit_checks<D: MembershipDigest>(
-        message: &[u8],
-        aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
-        protocol_message_preimage: &ProtocolMessagePreimage,
-        rolling_state: &IvcRollingState,
-    ) -> StmResult<IvcProverInputChecks<D>> {
-        let transition_type = IvcTransitionType::try_compute_transition_type(
-            rolling_state,
-            protocol_message_preimage,
-        )?;
+    // pub(crate) fn off_circuit_checks<D: MembershipDigest>(
+    //     message: &[u8],
+    //     aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
+    //     protocol_message_preimage: &ProtocolMessagePreimage,
+    //     rolling_state: &IvcRollingState,
+    // ) -> StmResult<IvcProverInputChecks<D>> {
+    //     let transition_type = IvcTransitionType::try_compute_transition_type(
+    //         rolling_state,
+    //         protocol_message_preimage,
+    //     )?;
 
-        rolling_state.assert_correct_parameters(
-            protocol_message_preimage,
-            aggregate_verification_key_for_snark,
-            message,
-            transition_type,
-        )?;
+    //     rolling_state.assert_correct_parameters(
+    //         protocol_message_preimage,
+    //         aggregate_verification_key_for_snark,
+    //         message,
+    //         transition_type,
+    //     )?;
 
-        let (certificate_message_hash, certificate_merkle_tree_commitment) =
-            create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
+    //     let (certificate_message_hash, certificate_merkle_tree_commitment) =
+    //         create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
 
-        assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
+    //     assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
 
-        Ok(IvcProverInputChecks {
-            transition_type,
-            certificate_message_hash,
-            certificate_merkle_tree_commitment,
-            message: message.to_vec(),
-            aggregate_verification_key_for_snark: aggregate_verification_key_for_snark.clone(),
-        })
-    }
+    //     Ok(IvcProverInputChecks {
+    //         transition_type,
+    //         certificate_message_hash,
+    //         certificate_merkle_tree_commitment,
+    //         message: message.to_vec(),
+    //         aggregate_verification_key_for_snark: aggregate_verification_key_for_snark.clone(),
+    //     })
+    // }
 
     /// Completes `prepare` once the certificate proof is available: verifies it, advances the
     /// chain state, and folds the accumulator. `checks` must come from [`Self::off_circuit_checks`]
@@ -150,11 +140,10 @@ impl IvcProverInput {
         rolling_state: &IvcRollingState,
         prover_setup: &IvcSnarkProverSetup,
     ) -> StmResult<Self> {
-        let checks = Self::off_circuit_checks(
+        let checks = rolling_state.off_circuit_checks(
             message,
             aggregate_verification_key_for_snark,
             protocol_message_preimage,
-            rolling_state,
         )?;
 
         Self::finish_preparation(

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
@@ -3,7 +3,7 @@ use midnight_curves::Bls12;
 use midnight_proofs::poly::kzg::msm::DualMSM;
 
 use crate::{
-    AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
+    AggregateVerificationKeyForSnark, BaseFieldElement, MembershipDigest, SnarkProof, StmResult,
     circuits::halo2_ivc::{
         errors::{EpochTransitionErrorKind, IvcCircuitError},
         state::{Global, State},
@@ -100,6 +100,19 @@ pub(crate) fn create_snark_message_for_next_state<D: MembershipDigest>(
     let certificate_message_hash = MessageHash::from_field(snark_message[1].0);
     let certificate_merkle_tree_commitment = MerkleTreeCommitment::from_field(snark_message[0].0);
     Ok((certificate_message_hash, certificate_merkle_tree_commitment))
+}
+
+/// Recomputes `SHA256(protocol_message_preimage)`, reduced into the base field (SHA256 digest, then
+/// little-endian base-256 reduction modulo the field), and checks it equals `expected_message`.
+pub(crate) fn assert_message_hash_matches_preimage(
+    expected_message: MessageHash,
+    protocol_message_preimage: &ProtocolMessagePreimage,
+) -> StmResult<()> {
+    let recomputed_message = BaseFieldElement::try_from(protocol_message_preimage.0.as_slice())?;
+    if MessageHash::from_field(recomputed_message.0) != expected_message {
+        return Err(IvcCircuitError::MessagePreimageMismatch.into());
+    }
+    Ok(())
 }
 
 /// Builds the non-genesis `State` for the next step. Advances the step counter
@@ -465,6 +478,38 @@ pub(crate) mod tests {
                     },
                     ..
                 }
+            ));
+        }
+    }
+
+    mod assert_message_hash_matches_preimage {
+        use super::*;
+
+        #[test]
+        fn accepts_message_matching_preimage_hash() {
+            let preimage = build_standard_preimage(EpochNumber::new(3));
+            let expected_message = MessageHash::from_field(
+                BaseFieldElement::try_from(preimage.0.as_slice())
+                    .expect("hashing should not fail")
+                    .0,
+            );
+
+            assert!(assert_message_hash_matches_preimage(expected_message, &preimage).is_ok());
+        }
+
+        #[test]
+        fn rejects_message_not_matching_preimage_hash() {
+            let preimage = build_standard_preimage(EpochNumber::new(3));
+
+            let err =
+                assert_message_hash_matches_preimage(MessageHash::ZERO, &preimage).unwrap_err();
+
+            let circuit_error = err
+                .downcast_ref::<IvcCircuitError>()
+                .expect("error chain should carry IvcCircuitError");
+            assert!(matches!(
+                circuit_error,
+                IvcCircuitError::MessagePreimageMismatch
             ));
         }
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
@@ -11,7 +11,10 @@ use crate::{
     },
     proof_system::{
         halo2_snark::build_snark_message,
-        ivc_halo2_snark::{prover_setup::IvcSnarkProverSetup, rolling_state::IvcRollingState},
+        ivc_halo2_snark::{
+            errors::IvcProofError, prover_setup::IvcSnarkProverSetup,
+            rolling_state::IvcRollingState,
+        },
     },
 };
 
@@ -146,7 +149,8 @@ pub(crate) fn build_next_state(
 }
 
 /// Folds the certificate proof's accumulator and the previous IVC proof's accumulator
-/// into the rolling state's accumulator, then collapses the result.
+/// into the rolling state's accumulator, then collapses the result. Check that the
+/// result verifies before returning it.
 ///
 /// The returned accumulator is the off-circuit twin of the one the in-circuit IVC
 /// verifier gadget computes from the same inputs; the new IVC proof commits to it.
@@ -168,6 +172,9 @@ pub(crate) fn build_next_accumulator(
         previous_ivc_proof_collapsed_accumulator,
     ]);
     next_accumulator.collapse();
+    if !next_accumulator.check(&setup.srs.verifier_params(), &setup.combined_fixed_bases) {
+        return Err(IvcProofError::InvalidNextAccumulator.into());
+    }
     Ok(next_accumulator)
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -138,9 +138,10 @@ impl IvcRollingState {
             == self.state.current_epoch.as_field() + EpochNumber::new(1).as_field()
     }
 
-    /// Asserts that protocol_parameters and next_protocol_parameters agree.
+    /// Asserts that protocol_parameters and next_protocol_parameters agree for
+    /// every step except genesis.
     pub(crate) fn assert_protocol_parameters_unchanged(&self) -> StmResult<()> {
-        if self.state.step_counter.is_not_first_step()
+        if !self.is_genesis()
             && self.state.protocol_parameters != self.state.next_protocol_parameters
         {
             return Err(IvcCircuitError::ProtocolParametersChanged.into());
@@ -521,7 +522,7 @@ mod tests {
         }
 
         #[test]
-        fn passes_at_first_step_even_when_protocol_parameters_differ() {
+        fn rejects_at_first_step_when_protocol_parameters_differ() {
             let rolling_state = build_rolling_state(
                 StepCounter::new(1),
                 EpochNumber::ZERO,
@@ -530,7 +531,14 @@ mod tests {
                 ProtocolParametersHash::from_field(BaseFieldElement::from(7u64).0),
             );
 
-            assert!(rolling_state.assert_protocol_parameters_unchanged().is_ok());
+            let err = rolling_state.assert_protocol_parameters_unchanged().unwrap_err();
+            let circuit_error = err
+                .downcast_ref::<IvcCircuitError>()
+                .expect("error chain should carry IvcCircuitError");
+            assert!(matches!(
+                circuit_error,
+                IvcCircuitError::ProtocolParametersChanged
+            ));
         }
 
         #[test]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -21,8 +21,8 @@ use crate::{
         },
     },
     proof_system::ivc_halo2_snark::{
-        IvcProverInput,
         errors::IvcProofError,
+        prover_input::IvcProverInput,
         prover_input_helpers::{
             IvcTransitionType, assert_message_hash_matches_preimage,
             create_snark_message_for_next_state,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -138,6 +138,16 @@ impl IvcRollingState {
             == self.state.current_epoch.as_field() + EpochNumber::new(1).as_field()
     }
 
+    /// Asserts that protocol_parameters and next_protocol_parameters agree.
+    pub(crate) fn assert_protocol_parameters_unchanged(&self) -> StmResult<()> {
+        if self.state.step_counter.is_not_first_step()
+            && self.state.protocol_parameters != self.state.next_protocol_parameters
+        {
+            return Err(IvcCircuitError::ProtocolParametersChanged.into());
+        }
+        Ok(())
+    }
+
     /// Asserts that the parameters in the rolling state matches the ones in
     /// the protocol message depending on the epoch transition type.
     /// This is done mainly to avoid computing a proof that will not verify.
@@ -290,7 +300,7 @@ mod tests {
     mod assert_correct_parameters {
         use crate::{
             MithrilMembershipDigest,
-            circuits::halo2_ivc::types::ProtocolParametersHash,
+            circuits::halo2_ivc::types::{MerkleTreeCommitment, ProtocolParametersHash},
             proof_system::{
                 AggregateVerificationKeyForSnark,
                 ivc_halo2_snark::prover_input_helpers::tests::{
@@ -493,6 +503,54 @@ mod tests {
             );
 
             assert!(result.is_ok());
+        }
+
+        #[test]
+        fn passes_when_protocol_parameters_match_past_first_step() {
+            let matching_parameters =
+                ProtocolParametersHash::from_field(BaseFieldElement::from(7u64).0);
+            let rolling_state = build_rolling_state(
+                StepCounter::new(2),
+                EpochNumber::new(3),
+                MerkleTreeCommitment::ZERO,
+                matching_parameters,
+                matching_parameters,
+            );
+
+            assert!(rolling_state.assert_protocol_parameters_unchanged().is_ok());
+        }
+
+        #[test]
+        fn passes_at_first_step_even_when_protocol_parameters_differ() {
+            let rolling_state = build_rolling_state(
+                StepCounter::new(1),
+                EpochNumber::ZERO,
+                MerkleTreeCommitment::ZERO,
+                ProtocolParametersHash::ZERO,
+                ProtocolParametersHash::from_field(BaseFieldElement::from(7u64).0),
+            );
+
+            assert!(rolling_state.assert_protocol_parameters_unchanged().is_ok());
+        }
+
+        #[test]
+        fn rejects_diverged_protocol_parameters_past_first_step() {
+            let rolling_state = build_rolling_state(
+                StepCounter::new(2),
+                EpochNumber::new(3),
+                MerkleTreeCommitment::ZERO,
+                ProtocolParametersHash::ZERO,
+                ProtocolParametersHash::from_field(BaseFieldElement::from(7u64).0),
+            );
+
+            let err = rolling_state.assert_protocol_parameters_unchanged().unwrap_err();
+            let circuit_error = err
+                .downcast_ref::<IvcCircuitError>()
+                .expect("error chain should carry IvcCircuitError");
+            assert!(matches!(
+                circuit_error,
+                IvcCircuitError::ProtocolParametersChanged
+            ));
         }
     }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     proof_system::ivc_halo2_snark::{
         IvcProverInput,
+        errors::IvcProofError,
         prover_input_helpers::{
             IvcTransitionType, assert_message_hash_matches_preimage,
             create_snark_message_for_next_state,
@@ -259,6 +260,22 @@ impl IvcRollingState {
         let (certificate_message_hash, _) =
             create_snark_message_for_next_state(aggregate_verification_key, message)?;
         assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)
+    }
+
+    /// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
+    ///
+    /// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
+    /// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
+    /// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
+    /// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
+    /// both-`None` misuses are now unrepresentable.
+    pub(crate) fn ensure_advanceable_rolling_state(
+        rolling_state: Option<&IvcRollingState>,
+    ) -> StmResult<()> {
+        if rolling_state.is_some_and(|rs| rs.is_genesis()) {
+            return Err(IvcProofError::InvalidProvingContext.into());
+        }
+        Ok(())
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -17,14 +17,28 @@ use crate::{
             accumulator::trivial_accumulator,
             errors::{EpochTransitionErrorKind, IvcCircuitError},
             state::{Global, State},
-            types::{IvcProofBytes, StepCounter},
+            types::{IvcProofBytes, MerkleTreeCommitment, MessageHash, StepCounter},
         },
     },
-    proof_system::ivc_halo2_snark::prover_input_helpers::{
-        IvcTransitionType, create_snark_message_for_next_state,
+    proof_system::ivc_halo2_snark::{
+        IvcProverInput,
+        prover_input_helpers::{
+            IvcTransitionType, assert_message_hash_matches_preimage,
+            create_snark_message_for_next_state,
+        },
     },
     signature_scheme::{BaseFieldElement, StandardSchnorrSignature},
 };
+
+/// Bundles [`IvcProverInput::off_circuit_checks`]'s outputs, carried into
+/// [`IvcProverInput::finish_preparation`] once the certificate proof is available.
+pub(crate) struct IvcProverInputChecks<D: MembershipDigest> {
+    pub(crate) transition_type: IvcTransitionType,
+    pub(crate) certificate_message_hash: MessageHash,
+    pub(crate) certificate_merkle_tree_commitment: MerkleTreeCommitment,
+    pub(crate) message: Vec<u8>,
+    pub(crate) aggregate_verification_key_for_snark: AggregateVerificationKeyForSnark<D>,
+}
 
 /// Caller-owned bridge between consecutive IVC proving steps.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -191,6 +205,60 @@ impl IvcRollingState {
         }
 
         Ok(())
+    }
+
+    /// Runs every `prepare` off circuit check that does not need the certificate proof:
+    /// classifies the step, validates the epoch advance and protocol-parameter lookahead
+    /// against the rolling state, and checks the message hashes to the supplied preimage.
+    pub(crate) fn off_circuit_checks<D: MembershipDigest>(
+        &self,
+        message: &[u8],
+        aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
+        protocol_message_preimage: &ProtocolMessagePreimage,
+    ) -> StmResult<IvcProverInputChecks<D>> {
+        let transition_type =
+            IvcTransitionType::try_compute_transition_type(self, protocol_message_preimage)?;
+
+        self.assert_correct_parameters(
+            protocol_message_preimage,
+            aggregate_verification_key_for_snark,
+            message,
+            transition_type,
+        )?;
+
+        let (certificate_message_hash, certificate_merkle_tree_commitment) =
+            create_snark_message_for_next_state(aggregate_verification_key_for_snark, message)?;
+
+        assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)?;
+
+        Ok(IvcProverInputChecks {
+            transition_type,
+            certificate_message_hash,
+            certificate_merkle_tree_commitment,
+            message: message.to_vec(),
+            aggregate_verification_key_for_snark: aggregate_verification_key_for_snark.clone(),
+        })
+    }
+
+    /// Runs [`IvcProverInput::prepare_genesis`]'s checks and discards the result: verifies the
+    /// genesis message hashes to `genesis_protocol_message_preimage`, then verifies the genesis
+    /// Schnorr signature. Additionally checks that the first real certificate's own message hashes
+    /// to `protocol_message_preimage`, mirroring [`off_circuit_checks`]'s hash check for the
+    /// non-genesis path. Exposed so a caller like `Clerk::aggregate_signatures_with_type` can reject
+    /// a malformed genesis request before generating the certificate proof.
+    pub(crate) fn off_circuit_genesis_checks<D: MembershipDigest>(
+        &self,
+        genesis_protocol_message_preimage: &ProtocolMessagePreimage,
+        global: &Global,
+        message: &[u8],
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+        protocol_message_preimage: &ProtocolMessagePreimage,
+    ) -> StmResult<()> {
+        IvcProverInput::prepare_genesis(self, genesis_protocol_message_preimage, global)?;
+
+        let (certificate_message_hash, _) =
+            create_snark_message_for_next_state(aggregate_verification_key, message)?;
+        assert_message_hash_matches_preimage(certificate_message_hash, protocol_message_preimage)
     }
 }
 

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,41 +1,21 @@
 use std::marker::PhantomData;
-#[cfg(feature = "future_snark")]
-use std::sync::Arc;
 
 use anyhow::Context;
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
-#[cfg(feature = "future_snark")]
-use midnight_proofs::transcript::Blake2b256;
-#[cfg(feature = "future_snark")]
-use rand_core::OsRng;
 
 use crate::{
     AggregateVerificationKey, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
     Signer, SingleSignature, Stake, StmResult, VerificationKeyForConcatenation,
     proof_system::{ConcatenationClerk, ConcatenationProof},
 };
-#[cfg(feature = "future_snark")]
-use crate::{
-    AggregationError,
-    circuits::{
-        halo2::keys::NonRecursiveCircuitVerifyingKey, halo2_ivc::PREIMAGE_SIZE,
-        key_provider::KeyProvider, trusted_setup::TrustedSetupProvider,
-    },
-    proof_system::ivc_halo2_snark::IvcSnarkProverSetup,
-};
 
 #[cfg(feature = "future_snark")]
 use crate::{
-    AggregateSignatureError, AncillaryProverData, AncillaryVerifierData, MithrilMembershipDigest,
-    circuits::halo2_ivc::{ProtocolMessagePreimage, state::Global},
+    AggregateSignatureError, AncillaryVerifierData,
     proof_system::{
         MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver, SnarkVerifierData,
-        ivc_halo2_snark::{
-            proof::{IvcGenesisBootstrapInput, IvcProof, IvcProver},
-            rolling_state::IvcRollingState,
-            verifier_setup::IvcVerifierData,
-        },
+        ivc_halo2_snark::PreparedIvcSnarkRequest,
     },
 };
 
@@ -150,11 +130,15 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
-                let prepared =
-                    prepare_and_check_ivc_snark_request(snark_clerk, &ancillary_input, msg)?;
+                let prepared_request =
+                    PreparedIvcSnarkRequest::prepare_and_check_ivc_snark_request(
+                        snark_clerk,
+                        &ancillary_input,
+                        msg,
+                    )?;
 
                 let (ivc_proof, next_ancillary_prover_data, ancillary_verifier_data) =
-                    prove_ivc_snark(prepared, sigs, msg, snark_clerk)?;
+                    prepared_request.prove_ivc_snark(sigs, msg, snark_clerk)?;
 
                 Ok((
                     AggregateSignature::IvcSnark(Box::new(ivc_proof)),
@@ -214,169 +198,6 @@ impl<D: MembershipDigest> Clerk<D> {
     pub fn update_m(&mut self, m: u64) {
         self.concatenation_proof_clerk.update_m(m);
     }
-}
-
-/// Bundles the outputs of [`prepare_and_check_ivc_snark_request`]: everything [`prove_ivc_snark`] needs to
-/// generate the certificate proof and complete IVC proving, once the request has passed every
-/// check that doesn't require that proof.
-#[cfg(feature = "future_snark")]
-struct PreparedIvcSnarkRequest<'a> {
-    ivc_prover_setup: Arc<IvcSnarkProverSetup>,
-    certificate_verifying_key: NonRecursiveCircuitVerifyingKey,
-    global: Global,
-    protocol_message_preimage: ProtocolMessagePreimage,
-    current_rolling_state: Option<&'a IvcRollingState>,
-    genesis_bootstrap: IvcGenesisBootstrapInput,
-}
-
-/// Loads the IVC prover setup, builds [`Global`], and runs every off circuit check that
-/// doesn't require the certificate proof: genesis verification key validity, rolling-state
-/// presence, protocol parameters unchanged, and message/preimage hash matching (genesis or
-/// non-genesis, depending on whether `ancillary_input` carries a rolling state).
-#[cfg(feature = "future_snark")]
-fn prepare_and_check_ivc_snark_request<'a>(
-    snark_clerk: &SnarkClerk,
-    ancillary_input: &'a AncillaryProofInput,
-    msg: &[u8],
-) -> StmResult<PreparedIvcSnarkRequest<'a>> {
-    let genesis_data = ancillary_input.genesis_data();
-    let genesis_verifying_key = genesis_data
-        .genesis_schnorr_verification_key()
-        .cloned()
-        .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
-    let genesis_message = genesis_data.genesis_message_preimage().try_into()?;
-    let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
-
-    let current_rolling_state = ancillary_input
-        .prover_data()
-        .map(|prover_data| {
-            prover_data.as_ivc_rolling_state().ok_or(anyhow!(
-                AggregationError::MissingIvcRollingStateInAncillaryProverData
-            ))
-        })
-        .transpose()?;
-    IvcRollingState::ensure_advanceable_rolling_state(current_rolling_state)?;
-
-    let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
-        ancillary_input.message_preimage().try_into()?;
-    let protocol_message_preimage = ProtocolMessagePreimage(protocol_message_preimage_bytes);
-
-    let trusted_setup_provider = TrustedSetupProvider::default();
-    let certificate_provider = KeyProvider::for_non_recursive_circuit(
-        &snark_clerk.parameters,
-        MERKLE_TREE_DEPTH_FOR_SNARK,
-    )?;
-    let recursive_key_provider = KeyProvider::for_recursive_circuit(certificate_provider);
-    let ivc_prover_setup = Arc::new(IvcSnarkProverSetup::load(
-        &trusted_setup_provider,
-        &recursive_key_provider,
-    )?);
-    let certificate_verifying_key = ivc_prover_setup.certificate_verifying_key.clone();
-
-    let global = Global::new(
-        genesis_message,
-        genesis_verifying_key,
-        &certificate_verifying_key,
-        &ivc_prover_setup.ivc_verifying_key,
-    )?;
-
-    let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
-
-    match current_rolling_state {
-        Some(rolling_state) => {
-            rolling_state.assert_protocol_parameters_unchanged()?;
-            rolling_state.off_circuit_checks(msg, &avk, &protocol_message_preimage)?;
-        }
-        None => {
-            let combined_fixed_base_names: Vec<String> =
-                ivc_prover_setup.combined_fixed_bases.keys().cloned().collect();
-            let genesis_rolling_state = IvcRollingState::genesis(
-                genesis_bootstrap.genesis_signature,
-                &combined_fixed_base_names,
-            );
-            genesis_rolling_state.off_circuit_genesis_checks(
-                &genesis_bootstrap.genesis_protocol_message_preimage,
-                &global,
-                msg,
-                &avk,
-                &protocol_message_preimage,
-            )?;
-        }
-    }
-
-    Ok(PreparedIvcSnarkRequest {
-        ivc_prover_setup,
-        certificate_verifying_key,
-        global,
-        protocol_message_preimage,
-        current_rolling_state,
-        genesis_bootstrap,
-    })
-}
-
-/// Generates the certificate proof and completes IVC proving for a request already validated by
-/// [`prepare_and_check_ivc_snark_request`].
-///
-/// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
-/// the step advances the epoch and `None` for same-epoch steps.
-///
-/// # Errors
-/// Fails if the message preimage is not PREIMAGE_SIZE bytes, or the proof itself fails.
-#[cfg(feature = "future_snark")]
-fn prove_ivc_snark(
-    prepared: PreparedIvcSnarkRequest,
-    sigs: &[SingleSignature],
-    msg: &[u8],
-    snark_clerk: &SnarkClerk,
-) -> StmResult<(
-    IvcProof<Blake2b256>,
-    Option<AncillaryProverData>,
-    AncillaryVerifierData,
-)> {
-    let snark_proof = SnarkProver::try_new_non_deterministic(
-        &snark_clerk.parameters,
-        MERKLE_TREE_DEPTH_FOR_SNARK,
-    )?
-    .aggregate_signatures::<MithrilMembershipDigest>(snark_clerk, sigs, msg)
-    .with_context(|| {
-        format!(
-            "Signatures failed to aggregate for type {}",
-            AggregateSignatureType::Snark
-        )
-    })?;
-
-    let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
-
-    let ivc_verifying_key = prepared.ivc_prover_setup.ivc_verifying_key.clone();
-
-    let mut prover = IvcProver {
-        ivc_setup: prepared.ivc_prover_setup,
-        rng: OsRng,
-    };
-
-    let (ivc_proof, next_rolling_state) = prover.prove(
-        snark_proof,
-        msg,
-        &avk,
-        &prepared.global,
-        &prepared.protocol_message_preimage,
-        &prepared.genesis_bootstrap,
-        prepared.current_rolling_state,
-    )?;
-
-    let next_ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
-
-    let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
-        prepared.global.genesis_message,
-        prepared.certificate_verifying_key,
-        ivc_verifying_key,
-    ));
-
-    Ok((
-        ivc_proof,
-        next_ancillary_prover_data,
-        ancillary_verifier_data,
-    ))
 }
 
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -150,6 +150,13 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
+                if let Some(prover_data) = ancillary_input.prover_data() {
+                    let rolling_state = prover_data.as_ivc_rolling_state().ok_or(anyhow!(
+                        AggregationError::MissingIvcRollingStateInAncillaryProverData
+                    ))?;
+                    rolling_state.assert_protocol_parameters_unchanged()?;
+                }
+
                 let snark_proof = SnarkProver::try_new_non_deterministic(
                     &snark_clerk.parameters,
                     MERKLE_TREE_DEPTH_FOR_SNARK,

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -299,7 +299,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         genesis_verifying_key,
         &certificate_verifying_key,
         &ivc_verifying_key,
-    );
+    )?;
 
     let mut prover = IvcProver {
         ivc_setup: ivc_prover_setup,

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -22,7 +22,7 @@ use crate::{
         halo2::keys::NonRecursiveCircuitVerifyingKey, halo2_ivc::PREIMAGE_SIZE,
         key_provider::KeyProvider, trusted_setup::TrustedSetupProvider,
     },
-    proof_system::ivc_halo2_snark::{IvcSnarkProverSetup, proof::ensure_advanceable_rolling_state},
+    proof_system::ivc_halo2_snark::IvcSnarkProverSetup,
 };
 
 #[cfg(feature = "future_snark")]
@@ -255,6 +255,7 @@ fn prepare_and_check_ivc_snark_request<'a>(
             ))
         })
         .transpose()?;
+    IvcRollingState::ensure_advanceable_rolling_state(current_rolling_state)?;
 
     let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
         ancillary_input.message_preimage().try_into()?;
@@ -281,7 +282,6 @@ fn prepare_and_check_ivc_snark_request<'a>(
 
     let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
 
-    ensure_advanceable_rolling_state(current_rolling_state)?;
     match current_rolling_state {
         Some(rolling_state) => {
             rolling_state.assert_protocol_parameters_unchanged()?;

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -22,7 +22,7 @@ use crate::{
         halo2::keys::NonRecursiveCircuitVerifyingKey, halo2_ivc::PREIMAGE_SIZE,
         key_provider::KeyProvider, trusted_setup::TrustedSetupProvider,
     },
-    proof_system::ivc_halo2_snark::IvcSnarkProverSetup,
+    proof_system::ivc_halo2_snark::{IvcSnarkProverSetup, proof::ensure_advanceable_rolling_state},
 };
 
 #[cfg(feature = "future_snark")]
@@ -33,8 +33,8 @@ use crate::{
         MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver, SnarkVerifierData,
         ivc_halo2_snark::{
             proof::{
-                IvcGenesisBootstrapInput, IvcProof, IvcProver, prepare_checks,
-                prepare_genesis_checks,
+                IvcGenesisBootstrapInput, IvcProof, IvcProver, off_circuit_checks,
+                off_circuit_genesis_checks,
             },
             rolling_state::IvcRollingState,
             verifier_setup::IvcVerifierData,
@@ -153,7 +153,8 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
-                let prepared = prepare_ivc_snark_request(snark_clerk, &ancillary_input, msg)?;
+                let prepared =
+                    prepare_and_check_ivc_snark_request(snark_clerk, &ancillary_input, msg)?;
 
                 let (ivc_proof, next_ancillary_prover_data, ancillary_verifier_data) =
                     prove_ivc_snark(prepared, sigs, msg, snark_clerk)?;
@@ -218,7 +219,7 @@ impl<D: MembershipDigest> Clerk<D> {
     }
 }
 
-/// Bundles the outputs of [`prepare_ivc_snark_request`]: everything [`prove_ivc_snark`] needs to
+/// Bundles the outputs of [`prepare_and_check_ivc_snark_request`]: everything [`prove_ivc_snark`] needs to
 /// generate the certificate proof and complete IVC proving, once the request has passed every
 /// check that doesn't require that proof.
 #[cfg(feature = "future_snark")]
@@ -236,7 +237,7 @@ struct PreparedIvcSnarkRequest<'a> {
 /// presence, protocol parameters unchanged, and message/preimage hash matching (genesis or
 /// non-genesis, depending on whether `ancillary_input` carries a rolling state).
 #[cfg(feature = "future_snark")]
-fn prepare_ivc_snark_request<'a>(
+fn prepare_and_check_ivc_snark_request<'a>(
     snark_clerk: &SnarkClerk,
     ancillary_input: &'a AncillaryProofInput,
     msg: &[u8],
@@ -281,13 +282,13 @@ fn prepare_ivc_snark_request<'a>(
         &ivc_prover_setup.ivc_verifying_key,
     )?;
 
+    let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+    ensure_advanceable_rolling_state(current_rolling_state)?;
     match current_rolling_state {
         Some(rolling_state) => {
             rolling_state.assert_protocol_parameters_unchanged()?;
 
-            let avk = snark_clerk
-                .compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
-            prepare_checks(msg, &avk, &protocol_message_preimage, rolling_state)?;
+            off_circuit_checks(msg, &avk, &protocol_message_preimage, rolling_state)?;
         }
         None => {
             let combined_fixed_base_names: Vec<String> =
@@ -296,7 +297,14 @@ fn prepare_ivc_snark_request<'a>(
                 genesis_bootstrap.genesis_signature,
                 &combined_fixed_base_names,
             );
-            prepare_genesis_checks(&genesis_rolling_state, &protocol_message_preimage, &global)?;
+            off_circuit_genesis_checks(
+                &genesis_rolling_state,
+                &genesis_bootstrap.genesis_protocol_message_preimage,
+                &global,
+                msg,
+                &avk,
+                &protocol_message_preimage,
+            )?;
         }
     }
 
@@ -311,7 +319,7 @@ fn prepare_ivc_snark_request<'a>(
 }
 
 /// Generates the certificate proof and completes IVC proving for a request already validated by
-/// [`prepare_ivc_snark_request`].
+/// [`prepare_and_check_ivc_snark_request`].
 ///
 /// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
 /// the step advances the epoch and `None` for same-epoch steps.
@@ -382,19 +390,24 @@ mod tests {
     use rand_core::SeedableRng;
 
     use crate::{
-        AncillaryGenesisData, AncillaryProofInput, Parameters, SchnorrSigningKey,
-        SchnorrVerificationKey,
-        circuits::halo2_ivc::PREIMAGE_SIZE,
+        AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
+        BaseFieldElement, Parameters, SchnorrSigningKey, SchnorrVerificationKey,
+        StandardSchnorrSignature, circuits::halo2_ivc::PREIMAGE_SIZE,
         protocol::aggregate_signature::tests::setup_equal_parties,
-        {AggregationError, AncillaryProverData},
     };
 
     use super::{AggregateSignatureType, Clerk};
 
-    fn valid_genesis_verification_key() -> SchnorrVerificationKey {
+    fn valid_genesis_verification_key_and_signature()
+    -> (StandardSchnorrSignature, SchnorrVerificationKey) {
         let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
         let signing_key = SchnorrSigningKey::generate(&mut rng);
-        SchnorrVerificationKey::new_from_signing_key(signing_key)
+        (
+            signing_key
+                .sign_standard(&[BaseFieldElement::get_one()], &mut rng)
+                .unwrap(),
+            SchnorrVerificationKey::new_from_signing_key(signing_key),
+        )
     }
 
     #[test]
@@ -408,10 +421,15 @@ mod tests {
         let ps = setup_equal_parties(tiny_params, 1);
         let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 
-        let genesis_verification_key = valid_genesis_verification_key();
+        let (schnorr_sig, genesis_verification_key) =
+            valid_genesis_verification_key_and_signature();
         let ancillary_input = AncillaryProofInput::new(
             Some(AncillaryProverData::Future),
-            AncillaryGenesisData::new(vec![0u8; 32], None, Some(genesis_verification_key)),
+            AncillaryGenesisData::new(
+                vec![0u8; PREIMAGE_SIZE],
+                Some(schnorr_sig),
+                Some(genesis_verification_key),
+            ),
             vec![0u8; PREIMAGE_SIZE],
         );
 

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -28,12 +28,15 @@ use crate::{
 #[cfg(feature = "future_snark")]
 use crate::{
     AggregateSignatureError, AncillaryProverData, AncillaryVerifierData, MithrilMembershipDigest,
-    SnarkProof,
     circuits::halo2_ivc::{ProtocolMessagePreimage, state::Global},
     proof_system::{
         MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver, SnarkVerifierData,
         ivc_halo2_snark::{
-            proof::{IvcProof, IvcProver},
+            proof::{
+                IvcGenesisBootstrapInput, IvcProof, IvcProver, prepare_checks,
+                prepare_genesis_checks,
+            },
+            rolling_state::IvcRollingState,
             verifier_setup::IvcVerifierData,
         },
     },
@@ -150,47 +153,10 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
-                if let Some(prover_data) = ancillary_input.prover_data() {
-                    let rolling_state = prover_data.as_ivc_rolling_state().ok_or(anyhow!(
-                        AggregationError::MissingIvcRollingStateInAncillaryProverData
-                    ))?;
-                    rolling_state.assert_protocol_parameters_unchanged()?;
-                }
-
-                let snark_proof = SnarkProver::try_new_non_deterministic(
-                    &snark_clerk.parameters,
-                    MERKLE_TREE_DEPTH_FOR_SNARK,
-                )?
-                .aggregate_signatures::<MithrilMembershipDigest>(snark_clerk, sigs, msg)
-                .with_context(|| {
-                    format!(
-                        "Signatures failed to aggregate for type {}",
-                        AggregateSignatureType::Snark
-                    )
-                })?;
-
-                let trusted_setup_provider = TrustedSetupProvider::default();
-                let certificate_provider = KeyProvider::for_non_recursive_circuit(
-                    &snark_clerk.parameters,
-                    MERKLE_TREE_DEPTH_FOR_SNARK,
-                )?;
-                let recursive_key_provider =
-                    KeyProvider::for_recursive_circuit(certificate_provider);
-                let ivc_prover_setup = Arc::new(IvcSnarkProverSetup::load(
-                    &trusted_setup_provider,
-                    &recursive_key_provider,
-                )?);
-                let certificate_verifying_key = ivc_prover_setup.certificate_verifying_key.clone();
+                let prepared = prepare_ivc_snark_request(snark_clerk, &ancillary_input, msg)?;
 
                 let (ivc_proof, next_ancillary_prover_data, ancillary_verifier_data) =
-                    ivc_prover_input_preparation_and_prove(
-                        snark_proof,
-                        msg,
-                        snark_clerk,
-                        &ancillary_input,
-                        ivc_prover_setup,
-                        certificate_verifying_key,
-                    )?;
+                    prove_ivc_snark(prepared, sigs, msg, snark_clerk)?;
 
                 Ok((
                     AggregateSignature::IvcSnark(Box::new(ivc_proof)),
@@ -252,41 +218,36 @@ impl<D: MembershipDigest> Clerk<D> {
     }
 }
 
-/// Prepares the IVC prover inputs from `ancillary_input` and the cached prover setup to
-/// build the [`Global`] chain constants, and run [`IvcProver::prove`].
-///
-/// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
-/// the step advances the epoch and `None` for same-epoch steps.
-///
-/// # Errors
-/// Fails if the genesis Schnorr verifying key is absent, the message preimage is not PREIMAGE_SIZE bytes,
-/// or the proof itself fails.
+/// Bundles the outputs of [`prepare_ivc_snark_request`]: everything [`prove_ivc_snark`] needs to
+/// generate the certificate proof and complete IVC proving, once the request has passed every
+/// check that doesn't require that proof.
 #[cfg(feature = "future_snark")]
-fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
-    snark_proof: SnarkProof<D>,
-    msg: &[u8],
-    clerk: &SnarkClerk,
-    ancillary_input: &AncillaryProofInput,
+struct PreparedIvcSnarkRequest<'a> {
     ivc_prover_setup: Arc<IvcSnarkProverSetup>,
     certificate_verifying_key: NonRecursiveCircuitVerifyingKey,
-) -> StmResult<(
-    IvcProof<Blake2b256>,
-    Option<AncillaryProverData>,
-    AncillaryVerifierData,
-)> {
-    let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
-        ancillary_input.message_preimage().try_into()?;
+    global: Global,
+    protocol_message_preimage: ProtocolMessagePreimage,
+    current_rolling_state: Option<&'a IvcRollingState>,
+    genesis_bootstrap: IvcGenesisBootstrapInput,
+}
 
+/// Loads the IVC prover setup, builds [`Global`], and runs every off circuit check that
+/// doesn't require the certificate proof: genesis verification key validity, rolling-state
+/// presence, protocol parameters unchanged, and message/preimage hash matching (genesis or
+/// non-genesis, depending on whether `ancillary_input` carries a rolling state).
+#[cfg(feature = "future_snark")]
+fn prepare_ivc_snark_request<'a>(
+    snark_clerk: &SnarkClerk,
+    ancillary_input: &'a AncillaryProofInput,
+    msg: &[u8],
+) -> StmResult<PreparedIvcSnarkRequest<'a>> {
     let genesis_data = ancillary_input.genesis_data();
-
     let genesis_verifying_key = genesis_data
         .genesis_schnorr_verification_key()
         .cloned()
         .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
-
     let genesis_message = genesis_data.genesis_message_preimage().try_into()?;
-
-    let ivc_verifying_key = ivc_prover_setup.ivc_verifying_key.clone();
+    let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
 
     let current_rolling_state = ancillary_input
         .prover_data()
@@ -297,19 +258,95 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         })
         .transpose()?;
 
-    let genesis_bootstrap = &genesis_data.try_into()?;
+    let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
+        ancillary_input.message_preimage().try_into()?;
+    let protocol_message_preimage = ProtocolMessagePreimage(protocol_message_preimage_bytes);
 
-    let avk = clerk.compute_aggregate_verification_key_for_snark();
+    let trusted_setup_provider = TrustedSetupProvider::default();
+    let certificate_provider = KeyProvider::for_non_recursive_circuit(
+        &snark_clerk.parameters,
+        MERKLE_TREE_DEPTH_FOR_SNARK,
+    )?;
+    let recursive_key_provider = KeyProvider::for_recursive_circuit(certificate_provider);
+    let ivc_prover_setup = Arc::new(IvcSnarkProverSetup::load(
+        &trusted_setup_provider,
+        &recursive_key_provider,
+    )?);
+    let certificate_verifying_key = ivc_prover_setup.certificate_verifying_key.clone();
 
     let global = Global::new(
         genesis_message,
         genesis_verifying_key,
         &certificate_verifying_key,
-        &ivc_verifying_key,
+        &ivc_prover_setup.ivc_verifying_key,
     )?;
 
+    match current_rolling_state {
+        Some(rolling_state) => {
+            rolling_state.assert_protocol_parameters_unchanged()?;
+
+            let avk = snark_clerk
+                .compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+            prepare_checks(msg, &avk, &protocol_message_preimage, rolling_state)?;
+        }
+        None => {
+            let combined_fixed_base_names: Vec<String> =
+                ivc_prover_setup.combined_fixed_bases.keys().cloned().collect();
+            let genesis_rolling_state = IvcRollingState::genesis(
+                genesis_bootstrap.genesis_signature,
+                &combined_fixed_base_names,
+            );
+            prepare_genesis_checks(&genesis_rolling_state, &protocol_message_preimage, &global)?;
+        }
+    }
+
+    Ok(PreparedIvcSnarkRequest {
+        ivc_prover_setup,
+        certificate_verifying_key,
+        global,
+        protocol_message_preimage,
+        current_rolling_state,
+        genesis_bootstrap,
+    })
+}
+
+/// Generates the certificate proof and completes IVC proving for a request already validated by
+/// [`prepare_ivc_snark_request`].
+///
+/// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
+/// the step advances the epoch and `None` for same-epoch steps.
+///
+/// # Errors
+/// Fails if the message preimage is not PREIMAGE_SIZE bytes, or the proof itself fails.
+#[cfg(feature = "future_snark")]
+fn prove_ivc_snark(
+    prepared: PreparedIvcSnarkRequest,
+    sigs: &[SingleSignature],
+    msg: &[u8],
+    snark_clerk: &SnarkClerk,
+) -> StmResult<(
+    IvcProof<Blake2b256>,
+    Option<AncillaryProverData>,
+    AncillaryVerifierData,
+)> {
+    let snark_proof = SnarkProver::try_new_non_deterministic(
+        &snark_clerk.parameters,
+        MERKLE_TREE_DEPTH_FOR_SNARK,
+    )?
+    .aggregate_signatures::<MithrilMembershipDigest>(snark_clerk, sigs, msg)
+    .with_context(|| {
+        format!(
+            "Signatures failed to aggregate for type {}",
+            AggregateSignatureType::Snark
+        )
+    })?;
+
+    let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+
+    let ivc_verifying_key = prepared.ivc_prover_setup.ivc_verifying_key.clone();
+
     let mut prover = IvcProver {
-        ivc_setup: ivc_prover_setup,
+        ivc_setup: prepared.ivc_prover_setup,
         rng: OsRng,
     };
 
@@ -317,17 +354,17 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         snark_proof,
         msg,
         &avk,
-        &global,
-        &ProtocolMessagePreimage(protocol_message_preimage_bytes),
-        genesis_bootstrap,
-        current_rolling_state,
+        &prepared.global,
+        &prepared.protocol_message_preimage,
+        &prepared.genesis_bootstrap,
+        prepared.current_rolling_state,
     )?;
 
     let next_ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
 
     let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
-        genesis_message,
-        certificate_verifying_key,
+        prepared.global.genesis_message,
+        prepared.certificate_verifying_key,
         ivc_verifying_key,
     ));
 
@@ -341,94 +378,51 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 #[cfg(feature = "future_snark")]
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
-
-    use midnight_curves::Bls12;
-    use midnight_proofs::poly::kzg::params::ParamsKZG;
-    use midnight_zk_stdlib::{self as zk, MidnightCircuit};
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
     use crate::{
-        AncillaryGenesisData, AncillaryProofInput, MithrilMembershipDigest, Parameters,
-        circuits::halo2::circuit::StmCertificateCircuit,
-        circuits::halo2::keys::NonRecursiveCircuitVerifyingKey,
+        AncillaryGenesisData, AncillaryProofInput, Parameters, SchnorrSigningKey,
+        SchnorrVerificationKey,
         circuits::halo2_ivc::PREIMAGE_SIZE,
-        circuits::halo2_ivc::keys::{RecursiveCircuitProvingKey, RecursiveCircuitVerifyingKey},
-        proof_system::SnarkClerk,
-        proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, ivc_halo2_snark::IvcSnarkProverSetup},
         protocol::aggregate_signature::tests::setup_equal_parties,
-        {AggregationError, AncillaryProverData, SnarkProof},
+        {AggregationError, AncillaryProverData},
     };
 
-    use super::ivc_prover_input_preparation_and_prove;
+    use super::{AggregateSignatureType, Clerk};
 
-    fn build_fast_dummy_ivc_setup(
-        params: Parameters,
-        depth: u32,
-    ) -> (Arc<IvcSnarkProverSetup>, NonRecursiveCircuitVerifyingKey) {
-        let circuit = StmCertificateCircuit::try_new(&params, depth)
-            .expect("certificate circuit should build");
-        let circuit_degree = MidnightCircuit::from_relation(&circuit, None).k();
-
-        let cert_srs =
-            ParamsKZG::<Bls12>::unsafe_setup(circuit_degree, ChaCha20Rng::from_seed([42u8; 32]));
-
-        let midnight_vk = zk::setup_vk(&cert_srs, &circuit);
-        let midnight_pk = zk::setup_pk(&circuit, &midnight_vk);
-        let cert_vk = midnight_vk.vk().clone();
-        // Not the correct key but we only need a dummy
-        let cert_pk = midnight_pk.pk().clone();
-
-        let ivc_setup = Arc::new(IvcSnarkProverSetup {
-            srs: cert_srs,
-            certificate_verifying_key: NonRecursiveCircuitVerifyingKey::new(midnight_vk.clone()),
-            ivc_verifying_key: RecursiveCircuitVerifyingKey::new(cert_vk),
-            ivc_proving_key: RecursiveCircuitProvingKey::new(cert_pk),
-            certificate_fixed_bases: BTreeMap::new(),
-            ivc_fixed_bases: BTreeMap::new(),
-            combined_fixed_bases: BTreeMap::new(),
-        });
-
-        (ivc_setup, NonRecursiveCircuitVerifyingKey::new(midnight_vk))
+    fn valid_genesis_verification_key() -> SchnorrVerificationKey {
+        let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
+        let signing_key = SchnorrSigningKey::generate(&mut rng);
+        SchnorrVerificationKey::new_from_signing_key(signing_key)
     }
 
     #[test]
-    fn ivc_prover_input_preparation_fails_when_prover_data_carries_no_ivc_rolling_state() {
-        use crate::SchnorrVerificationKey;
-
+    fn aggregate_signatures_with_type_ivc_snark_fails_when_prover_data_carries_no_ivc_rolling_state()
+     {
         let tiny_params = Parameters {
             k: 1,
             m: 10,
             phi_f: 0.9,
         };
-        let (ivc_prover_setup, certificate_verifying_key) =
-            build_fast_dummy_ivc_setup(tiny_params, 1);
-
         let ps = setup_equal_parties(tiny_params, 1);
-        let snark_clerk = SnarkClerk::new_clerk_from_signer(&ps[0]);
-        let snark_proof = SnarkProof::<MithrilMembershipDigest>::new(
-            vec![],
-            tiny_params,
-            MERKLE_TREE_DEPTH_FOR_SNARK,
-        );
+        let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 
+        let genesis_verification_key = valid_genesis_verification_key();
         let ancillary_input = AncillaryProofInput::new(
             Some(AncillaryProverData::Future),
-            AncillaryGenesisData::new(vec![0u8; 32], None, Some(SchnorrVerificationKey::default())),
+            AncillaryGenesisData::new(vec![0u8; 32], None, Some(genesis_verification_key)),
             vec![0u8; PREIMAGE_SIZE],
         );
 
-        let err = ivc_prover_input_preparation_and_prove(
-            snark_proof,
-            &[0u8; 32],
-            &snark_clerk,
-            &ancillary_input,
-            ivc_prover_setup,
-            certificate_verifying_key,
-        )
-        .expect_err("Should fail without IVC rolling state.");
+        let err = clerk
+            .aggregate_signatures_with_type(
+                &[],
+                &[0u8; 32],
+                AggregateSignatureType::IvcSnark,
+                ancillary_input,
+            )
+            .expect_err("Should fail without IVC rolling state.");
 
         assert_eq!(
             err.downcast_ref::<AggregationError>(),
@@ -438,22 +432,14 @@ mod tests {
     }
 
     #[test]
-    fn ivc_prover_input_preparation_fails_when_genesis_verification_key_is_absent() {
+    fn aggregate_signatures_with_type_ivc_snark_fails_when_genesis_verification_key_is_absent() {
         let tiny_params = Parameters {
             k: 1,
             m: 10,
             phi_f: 0.9,
         };
-        let (ivc_prover_setup, certificate_verifying_key) =
-            build_fast_dummy_ivc_setup(tiny_params, 1);
-
         let ps = setup_equal_parties(tiny_params, 1);
-        let snark_clerk = SnarkClerk::new_clerk_from_signer(&ps[0]);
-        let snark_proof = SnarkProof::<MithrilMembershipDigest>::new(
-            vec![],
-            tiny_params,
-            MERKLE_TREE_DEPTH_FOR_SNARK,
-        );
+        let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 
         let ancillary_input = AncillaryProofInput::new(
             None,
@@ -461,15 +447,14 @@ mod tests {
             vec![0u8; PREIMAGE_SIZE],
         );
 
-        let err = ivc_prover_input_preparation_and_prove(
-            snark_proof,
-            &[0u8; 32],
-            &snark_clerk,
-            &ancillary_input,
-            ivc_prover_setup,
-            certificate_verifying_key,
-        )
-        .expect_err("Should fail without genesis verification key.");
+        let err = clerk
+            .aggregate_signatures_with_type(
+                &[],
+                &[0u8; 32],
+                AggregateSignatureType::IvcSnark,
+                ancillary_input,
+            )
+            .expect_err("Should fail without genesis verification key.");
 
         assert_eq!(
             err.downcast_ref::<AggregationError>(),

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -32,10 +32,7 @@ use crate::{
     proof_system::{
         MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver, SnarkVerifierData,
         ivc_halo2_snark::{
-            proof::{
-                IvcGenesisBootstrapInput, IvcProof, IvcProver, off_circuit_checks,
-                off_circuit_genesis_checks,
-            },
+            proof::{IvcGenesisBootstrapInput, IvcProof, IvcProver},
             rolling_state::IvcRollingState,
             verifier_setup::IvcVerifierData,
         },
@@ -283,12 +280,12 @@ fn prepare_and_check_ivc_snark_request<'a>(
     )?;
 
     let avk = snark_clerk.compute_aggregate_verification_key_for_snark::<MithrilMembershipDigest>();
+
     ensure_advanceable_rolling_state(current_rolling_state)?;
     match current_rolling_state {
         Some(rolling_state) => {
             rolling_state.assert_protocol_parameters_unchanged()?;
-
-            off_circuit_checks(msg, &avk, &protocol_message_preimage, rolling_state)?;
+            rolling_state.off_circuit_checks(msg, &avk, &protocol_message_preimage)?;
         }
         None => {
             let combined_fixed_base_names: Vec<String> =
@@ -297,8 +294,7 @@ fn prepare_and_check_ivc_snark_request<'a>(
                 genesis_bootstrap.genesis_signature,
                 &combined_fixed_base_names,
             );
-            off_circuit_genesis_checks(
-                &genesis_rolling_state,
+            genesis_rolling_state.off_circuit_genesis_checks(
                 &genesis_bootstrap.genesis_protocol_message_preimage,
                 &global,
                 msg,

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -211,7 +211,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     genesis_verification_key_bundle.schnorr,
                     ivc_verifier_data.certificate_circuit_verification_key(),
                     ivc_verifier_data.ivc_circuit_verification_key(),
-                );
+                )?;
 
                 let verifier_setup = IvcVerifierSetup::try_new(
                     ivc_verifier_data.certificate_circuit_verification_key(),


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes the addition of some missing off circuit checks. The goal of those checks is to prevent a prover from trying to create a proof that will fail to verify since the proof creation is a very expensive operations.

## Changes

- Validation of the protocol message hash: it was not done off circuit yet but is done at every step in circuit. Recompute the hash of the protocol message preimage and compares it to the MessageHash received.
- Check of the validity of the genesis verification key: verifies the key is an actual point on the elliptic curve. The check is done at every step (even post genesis) in circuit.
- Check that the protocol parameters do not evolve from one epoch to the next: check that `protocol_parameters == next_protocol_parameters` for the values coming from the rolling state. An update of the parameters would break the recursive proof.
- Moved all the checks to before the generation of the non recursive proof to allow a failure before the heavy computation: This implied a big restructure of the code around the call to the IVC prover


## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3381 
