### PR TITLE
fix: anticipate Rust `1.98` clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.5", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.6", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "1.1.7"
+version = "1.1.8"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/tests/test_extensions/fake_aggregator_http.rs
+++ b/mithril-signer/tests/test_extensions/fake_aggregator_http.rs
@@ -166,11 +166,13 @@ impl FakeAggregatorRoutesState {
     }
 }
 
-fn internal_server_error(err: StdError) -> Response {
-    (StatusCode::INTERNAL_SERVER_ERROR, Json(err.to_string())).into_response()
+fn internal_server_error(err: StdError) -> (StatusCode, Json<String>) {
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(err.to_string()))
 }
 
-async fn epoch_settings(state: State<FakeAggregatorRoutesState>) -> Result<Response, Response> {
+async fn epoch_settings(
+    state: State<FakeAggregatorRoutesState>,
+) -> Result<Response, (StatusCode, Json<String>)> {
     slog::debug!(state.logger, "/epoch-settings");
 
     if state.store.read().await.withhold_epoch_settings {

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.5"
+version = "0.12.6"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/embedded_assets.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/embedded_assets.rs
@@ -46,7 +46,8 @@ use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 pub(crate) fn jubjub_base_from_raw_le_bytes(bytes: &[u8]) -> NativeField {
     assert_eq!(bytes.len(), 32);
     let mut limbs = [0u64; 4];
-    for (limb, chunk) in limbs.iter_mut().zip(bytes.chunks_exact(8)) {
+    let (chunks, _remainder) = bytes.as_chunks::<8>();
+    for (limb, chunk) in limbs.iter_mut().zip(chunks) {
         let mut le_bytes = [0u8; 8];
         le_bytes.copy_from_slice(chunk);
         *limb = u64::from_le_bytes(le_bytes);

--- a/mithril-stm/src/hash/poseidon.rs
+++ b/mithril-stm/src/hash/poseidon.rs
@@ -55,9 +55,9 @@ impl FixedOutput for MidnightPoseidonDigest {
         // The data is padded during the call to the update function
         // so there should always be a multiple of 32 bytes in the buffer
         // We are taking chunks of 32 u8 so it should be fine to unwrap
-        let poseidon_input = self
-            .buffer
-            .chunks_exact(32)
+        let (chunks, _remainder) = self.buffer.as_chunks::<32>();
+        let poseidon_input = chunks
+            .iter()
             .map(|chunk| {
                 // The from_raw function performs a modular reduction so
                 // it will never fail even if the buffer value exceeds

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.12"
+version = "0.5.13"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -57,7 +57,7 @@ impl CardanoDbV2Command {
                     "--include-ancillary".to_string(),
                     "--allow-override".to_string(),
                     "--download-dir".to_string(),
-                    format!("v2"),
+                    "v2".to_string(),
                     hash.clone(),
                 ]
             }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
@@ -109,7 +109,7 @@ pub async fn compute_mithril_stake_distribution_signatures(
             Ok(signatures)
         },
         timeout,
-        format!("Compute signatures for MithrilStakeDistribution signed entity"),
+        "Compute signatures for MithrilStakeDistribution signed entity".to_string(),
         format!("Computing signatures timeout after {timeout:?}")
     )
 }
@@ -184,7 +184,7 @@ pub async fn compute_immutable_files_signatures(
             Ok((beacon, signatures))
         },
         timeout,
-        format!("Compute signatures for CardanoImmutableFiles signed entity"),
+        "Compute signatures for CardanoImmutableFiles signed entity".to_string(),
         format!("Computing signatures timeout after {timeout:?}")
     )
 }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
@@ -129,7 +129,7 @@ pub async fn for_certificates(
                 .map_err(|e| anyhow!(e).context("Request first certificate failure"))
         },
         timeout,
-        format!("Waiting for certificates"),
+        "Waiting for certificates".to_string(),
         format!("Aggregator did not get a response after {timeout:?} from '{url}'")
     )
 }
@@ -153,7 +153,7 @@ pub async fn for_mithril_stake_distribution_artifacts(
             .map_err(|e| anyhow!(e).context("Request first mithril stake distribution failure"))
         },
         timeout,
-        format!("Waiting for mithril stake distribution artifacts"),
+        "Waiting for mithril stake distribution artifacts".to_string(),
         format!("Aggregator did not get a response after {timeout:?} from '{url}'")
     )
 }
@@ -174,7 +174,7 @@ pub async fn for_immutable_files_artifacts(
             .map_err(|e| anyhow!(e).context("Request first snapshot failure"))
         },
         timeout,
-        format!("Waiting for immutable files artifacts"),
+        "Waiting for immutable files artifacts".to_string(),
         format!("Aggregator did not get a response after {timeout:?} from '{url}'")
     )
 }


### PR DESCRIPTION
## Content

This PR fix preemptively clippy lints added or updated with [`rust 1.98`](https://releases.rs/docs/1.98.0/).

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
  - [x] No new TODOs introduced

## Issue(s)

Closes #3484