### PR TITLE
fix admonitions and update footer discord

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -310,7 +310,7 @@ const config = {
             title: "Community",
             items: [
               {
-                label: "Discord (#ask-mithril)",
+                label: "Discord (#general-mithril)",
                 href: "https://discord.gg/5kaErDKDRq",
               },
               {

--- a/docs/website/versioned_docs/version-maintained/mithril/advanced/mithril-protocol/protocol.md
+++ b/docs/website/versioned_docs/version-maintained/mithril/advanced/mithril-protocol/protocol.md
@@ -44,7 +44,7 @@ The protocol has three phases:
 2. **Initialization phase** during which Mithril nodes generate and exchange keys
 3. **Operations phase** during which nodes sign and aggregate signatures of messages to produce certificates.
 
-:::note Note
+:::note[Note]
 
 Note that all three phases require a set of parties (`P` in the paper) to be fixed. During the protocol establishment phase
 three important parameters are generated:
@@ -118,7 +118,7 @@ a quorum of `k` valid signatures must be submitted.
 
 - Each certificate `τ` can be verified as valid for some message, using the known setup parameters to verify the certificate’s proof and then verifying the aggregate signatures and verification keys.
 
-:::note Note
+:::note[Note]
 
 Note that if the individual signatures are broadcast to all parties, then each party can independently produce the certificates. In particular, the party that performs aggregation is not required to have any specific knowledge, nor it is assumed to be honest. This means that _any_ third party that has access to the individual signatures can perform the signature aggregation.
 


### PR DESCRIPTION
## Content

Just a nit, fixed admonition bug on `/doc/mithril/advanced/mithril-protocol/protocol/` and replaced the name of the Discord channel in the footer.

## Pre-submit checklist

- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments

None

## Issue(s)

Closes #3491 