### PR TITLE
test(stm): split the IVC prover monolith into separated tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.10", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.11", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.11 (08-31-2026)
+
+### Changed
+
+- Split the monolithic `prove_all_scenarios` slow test into a bootstrap test and a mature same-epoch test, and dropped the mature next-epoch proving, so that the IVC prover tier generates four real proofs instead of six while still covering every reachable transition type and transcript pair.
+- Moved the prover rejection scenarios to the fast tier as `IvcProverInput::prepare` tests asserting typed errors, and deleted the one duplicating an existing case, so that they run on every pull request rather than the nightly only.
+- Built the slow test context from the committed genesis benchmark fixture instead of the asset generation setup, so that the prover tests consume only the committed inputs they exercise.
+
 ## 0.12.10 (08-28-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.10"
+version = "0.12.11"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -977,10 +977,7 @@ mod tests {
         use std::sync::Arc;
         use std::time::Instant;
 
-        use midnight_circuits::{
-            hash::poseidon::PoseidonState, verifier::Accumulator, verifier::BlstrsEmulation,
-        };
-        use midnight_proofs::utils::SerdeFormat;
+        use midnight_circuits::hash::poseidon::PoseidonState;
         use rand_core::OsRng;
 
         use crate::{
@@ -988,14 +985,12 @@ mod tests {
             circuits::{
                 halo2::types::CircuitBase,
                 halo2_ivc::{
-                    io::Write as IvcWrite,
                     state::Global,
                     tests::common::{
                         asset_readers::{
                             RecursiveChainStateAsset,
                             load_embedded_first_certificate_in_epoch_asset,
                             load_embedded_following_certificate_in_epoch_asset,
-                            load_embedded_next_epoch_step_output_asset,
                             load_embedded_recursive_chain_state_asset,
                             load_embedded_verification_context_asset,
                         },
@@ -1070,16 +1065,65 @@ mod tests {
             )
         }
 
-        fn accumulator_bytes(accumulator: &Accumulator<BlstrsEmulation>) -> Vec<u8> {
-            let mut bytes = Vec::new();
-            accumulator
-                .write(&mut bytes, SerdeFormat::RawBytesUnchecked)
-                .expect("accumulator serialization should succeed");
-            bytes
+        fn build_slow_test_context() -> SlowTestContext {
+            let t_setup = Instant::now();
+            let parameters = Parameters {
+                k: QUORUM_SIZE as u64,
+                m: (QUORUM_SIZE * 10) as u64,
+                phi_f: 0.2,
+            };
+            let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
+            let ivc_setup = Arc::new(
+                IvcSnarkProverSetup::build_for_test(&parameters, merkle_tree_depth)
+                    .expect("IvcSnarkProverSetup::load should succeed"),
+            );
+
+            let verification_context = load_embedded_verification_context_asset()
+                .expect("verification context asset should load");
+            let asset_setup = build_asset_generation_setup_from_cache();
+
+            assert_eq!(
+                verification_context
+                    .certificate_verifying_key
+                    .midnight_vk()
+                    .vk()
+                    .transcript_repr(),
+                ivc_setup
+                    .certificate_verifying_key
+                    .midnight_vk()
+                    .vk()
+                    .transcript_repr(),
+                "stored verification context cert VK must match freshly generated cert VK"
+            );
+            assert_eq!(
+                verification_context
+                    .recursive_verifying_key
+                    .verifying_key()
+                    .transcript_repr(),
+                ivc_setup.ivc_verifying_key.verifying_key().transcript_repr(),
+                "stored verification context IVC VK must match freshly generated IVC VK"
+            );
+
+            let global = build_recursive_global(
+                &asset_setup,
+                &verification_context.certificate_verifying_key,
+                &verification_context.recursive_verifying_key,
+            );
+            let verifier_setup = IvcVerifierSetup::from_ivc_setup_with_srs(&ivc_setup);
+            println!("[setup] {:.1}s", t_setup.elapsed().as_secs_f64());
+
+            SlowTestContext {
+                ivc_setup,
+                global,
+                verifier_setup,
+                asset_setup,
+            }
         }
 
-        fn run_bootstrap_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
+        #[test]
+        fn prove_bootstrap_produces_first_epoch_proof_and_rolling_state() {
+            let ctx = build_slow_test_context();
+
             let first_step = load_embedded_first_certificate_in_epoch_asset()
                 .expect("first-step certificate asset should load");
             let avk = wrap_avk(&first_step.aggregate_verification_key_merkle_root);
@@ -1135,73 +1179,12 @@ mod tests {
                 &ctx.verifier_setup,
             )
             .expect("bootstrap Poseidon proof must verify");
-
-            println!("[bootstrap] {:.1}s", t.elapsed().as_secs_f64());
         }
 
-        fn run_next_epoch_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let rolling_state = rolling_state_from_asset(
-                load_embedded_recursive_chain_state_asset()
-                    .expect("recursive chain state asset should load"),
-            );
-            let step = load_embedded_next_epoch_step_output_asset()
-                .expect("next-epoch step output asset should load");
+        #[test]
+        fn prove_same_epoch_produces_proof_without_rolling_state() {
+            let ctx = build_slow_test_context();
 
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let (blake2b_proof, rolling) = prover
-                .prove(
-                    snark_proof,
-                    step.message.as_ref(),
-                    &avk,
-                    &ctx.global,
-                    &preimage,
-                    &genesis_bootstrap(&ctx.asset_setup),
-                    Some(&rolling_state),
-                )
-                .expect("next-epoch prove should succeed");
-
-            let next_rolling = rolling.expect("next-epoch must return a rolling state");
-
-            assert_eq!(
-                &blake2b_proof.state, &step.next_state,
-                "next-epoch Blake2b proof state must match embedded asset output"
-            );
-            assert_eq!(
-                next_rolling.state(),
-                &step.next_state,
-                "next-epoch rolling state must match embedded asset output"
-            );
-            assert_eq!(
-                accumulator_bytes(next_rolling.accumulator()),
-                accumulator_bytes(&step.next_accumulator),
-                "next-epoch rolling accumulator must match embedded asset output"
-            );
-
-            blake2b_proof
-                .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
-                .expect("next-epoch Blake2b proof must verify");
-
-            IvcProof::<PoseidonState<CircuitBase>>::new(
-                next_rolling.ivc_proof().clone(),
-                next_rolling.state().clone(),
-                next_rolling.accumulator().clone(),
-            )
-            .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
-            .expect("next-epoch Poseidon proof must verify");
-
-            println!("[next-epoch] {:.1}s", t.elapsed().as_secs_f64());
-        }
-
-        fn run_same_epoch_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
             let rolling_state = rolling_state_from_asset(
                 load_embedded_recursive_chain_state_asset()
                     .expect("recursive chain state asset should load"),
@@ -1242,68 +1225,6 @@ mod tests {
             blake2b_proof
                 .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
                 .expect("same-epoch Blake2b proof must verify");
-
-            println!("[same-epoch] {:.1}s", t.elapsed().as_secs_f64());
-        }
-
-        #[test]
-        fn prove_all_scenarios() {
-            let t_setup = Instant::now();
-            let parameters = Parameters {
-                k: QUORUM_SIZE as u64,
-                m: (QUORUM_SIZE * 10) as u64,
-                phi_f: 0.2,
-            };
-            let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
-            let ivc_setup = Arc::new(
-                IvcSnarkProverSetup::build_for_test(&parameters, merkle_tree_depth)
-                    .expect("IvcSnarkProverSetup::load should succeed"),
-            );
-
-            let verification_context = load_embedded_verification_context_asset()
-                .expect("verification context asset should load");
-            let asset_setup = build_asset_generation_setup_from_cache();
-
-            assert_eq!(
-                verification_context
-                    .certificate_verifying_key
-                    .midnight_vk()
-                    .vk()
-                    .transcript_repr(),
-                ivc_setup
-                    .certificate_verifying_key
-                    .midnight_vk()
-                    .vk()
-                    .transcript_repr(),
-                "stored verification context cert VK must match freshly generated cert VK"
-            );
-            assert_eq!(
-                verification_context
-                    .recursive_verifying_key
-                    .verifying_key()
-                    .transcript_repr(),
-                ivc_setup.ivc_verifying_key.verifying_key().transcript_repr(),
-                "stored verification context IVC VK must match freshly generated IVC VK"
-            );
-
-            let global = build_recursive_global(
-                &asset_setup,
-                &verification_context.certificate_verifying_key,
-                &verification_context.recursive_verifying_key,
-            );
-            let verifier_setup = IvcVerifierSetup::from_ivc_setup_with_srs(&ivc_setup);
-            println!("[setup] {:.1}s", t_setup.elapsed().as_secs_f64());
-
-            let ctx = SlowTestContext {
-                ivc_setup,
-                global,
-                verifier_setup,
-                asset_setup,
-            };
-
-            run_bootstrap_path(&ctx);
-            run_next_epoch_path(&ctx);
-            run_same_epoch_path(&ctx);
         }
     }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -1054,7 +1054,7 @@ mod tests {
             let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
             let ivc_setup = Arc::new(
                 IvcSnarkProverSetup::build_for_test(&parameters, merkle_tree_depth)
-                    .expect("IvcSnarkProverSetup::load should succeed"),
+                    .expect("IvcSnarkProverSetup::build_for_test should succeed"),
             );
 
             let verification_context = load_embedded_verification_context_asset()

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -991,14 +991,11 @@ mod tests {
                             RecursiveChainStateAsset,
                             load_embedded_first_certificate_in_epoch_asset,
                             load_embedded_following_certificate_in_epoch_asset,
+                            load_embedded_genesis_benchmark_fixture,
                             load_embedded_recursive_chain_state_asset,
                             load_embedded_verification_context_asset,
                         },
-                        generators::{
-                            build_asset_generation_setup_from_cache,
-                            build_genesis_protocol_message_preimage, build_recursive_global,
-                            setup::{AssetGenerationSetup, QUORUM_SIZE, SIGNER_COUNT, TOTAL_STAKE},
-                        },
+                        generators::setup::{QUORUM_SIZE, SIGNER_COUNT, TOTAL_STAKE},
                     },
                     types::ProtocolMessagePreimage,
                 },
@@ -1015,7 +1012,7 @@ mod tests {
             ivc_setup: Arc<IvcSnarkProverSetup>,
             global: Global,
             verifier_setup: IvcVerifierSetup,
-            asset_setup: AssetGenerationSetup,
+            genesis_bootstrap: IvcGenesisBootstrapInput,
         }
 
         fn wrap_snark_proof(
@@ -1036,24 +1033,6 @@ mod tests {
             avk_bytes[32..40].copy_from_slice(&TOTAL_STAKE.to_be_bytes());
             AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_bytes)
                 .expect("AVK should decode from bytes")
-        }
-
-        fn wrap_protocol_message_preimage(preimage: &[u8]) -> ProtocolMessagePreimage {
-            use crate::circuits::halo2_ivc::PREIMAGE_SIZE;
-            let preimage_array: [u8; PREIMAGE_SIZE] = preimage
-                .try_into()
-                .expect("preimage should be exactly PREIMAGE_SIZE bytes");
-            ProtocolMessagePreimage::new(preimage_array)
-        }
-
-        fn genesis_bootstrap(asset_setup: &AssetGenerationSetup) -> IvcGenesisBootstrapInput {
-            let genesis_preimage_bytes = build_genesis_protocol_message_preimage(asset_setup);
-            IvcGenesisBootstrapInput {
-                genesis_signature: asset_setup.genesis_signature,
-                genesis_protocol_message_preimage: wrap_protocol_message_preimage(
-                    &genesis_preimage_bytes,
-                ),
-            }
         }
 
         fn rolling_state_from_asset(asset: RecursiveChainStateAsset) -> IvcRollingState {
@@ -1080,7 +1059,8 @@ mod tests {
 
             let verification_context = load_embedded_verification_context_asset()
                 .expect("verification context asset should load");
-            let asset_setup = build_asset_generation_setup_from_cache();
+            let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+                .expect("genesis benchmark fixture should load");
 
             assert_eq!(
                 verification_context
@@ -1104,11 +1084,18 @@ mod tests {
                 "stored verification context IVC VK must match freshly generated IVC VK"
             );
 
-            let global = build_recursive_global(
-                &asset_setup,
+            let global = Global::new(
+                genesis_fixture.genesis_message_hash(),
+                genesis_fixture.genesis_verification_key,
                 &verification_context.certificate_verifying_key,
                 &verification_context.recursive_verifying_key,
             );
+            let genesis_bootstrap = IvcGenesisBootstrapInput {
+                genesis_signature: genesis_fixture.genesis_signature,
+                genesis_protocol_message_preimage: ProtocolMessagePreimage::new(
+                    genesis_fixture.genesis_protocol_message_preimage,
+                ),
+            };
             let verifier_setup = IvcVerifierSetup::from_ivc_setup_with_srs(&ivc_setup);
             println!("[setup] {:.1}s", t_setup.elapsed().as_secs_f64());
 
@@ -1116,7 +1103,7 @@ mod tests {
                 ivc_setup,
                 global,
                 verifier_setup,
-                asset_setup,
+                genesis_bootstrap,
             }
         }
 
@@ -1128,8 +1115,7 @@ mod tests {
                 .expect("first-step certificate asset should load");
             let avk = wrap_avk(&first_step.aggregate_verification_key_merkle_root);
             let snark_proof = wrap_snark_proof(first_step.certificate_proof.clone().into_vec());
-            let epoch1_preimage = wrap_protocol_message_preimage(&first_step.message_preimage);
-            let bootstrap = genesis_bootstrap(&ctx.asset_setup);
+            let epoch1_preimage = ProtocolMessagePreimage::new(first_step.message_preimage);
 
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),
@@ -1143,7 +1129,7 @@ mod tests {
                     &avk,
                     &ctx.global,
                     &epoch1_preimage,
-                    &bootstrap,
+                    &ctx.genesis_bootstrap,
                     None,
                 )
                 .expect("bootstrap prove should succeed");
@@ -1194,7 +1180,7 @@ mod tests {
 
             let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
             let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
+            let preimage = ProtocolMessagePreimage::new(step.message_preimage);
 
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),
@@ -1207,7 +1193,8 @@ mod tests {
                     &avk,
                     &ctx.global,
                     &preimage,
-                    &genesis_bootstrap(&ctx.asset_setup),
+                    // Ignored when continuing from an existing rolling state.
+                    &ctx.genesis_bootstrap,
                     Some(&rolling_state),
                 )
                 .expect("same-epoch prove should succeed");

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -1005,14 +1005,13 @@ mod tests {
                             setup::{AssetGenerationSetup, QUORUM_SIZE, SIGNER_COUNT, TOTAL_STAKE},
                         },
                     },
-                    types::{IvcProofBytes, MessageHash, ProtocolMessagePreimage},
+                    types::ProtocolMessagePreimage,
                 },
             },
             proof_system::ivc_halo2_snark::{
                 prover_setup::IvcSnarkProverSetup, rolling_state::IvcRollingState,
                 verifier_setup::IvcVerifierSetup,
             },
-            signature_scheme::BaseFieldElement,
         };
 
         use super::super::{IvcGenesisBootstrapInput, IvcProof, IvcProver};
@@ -1247,206 +1246,6 @@ mod tests {
             println!("[same-epoch] {:.1}s", t.elapsed().as_secs_f64());
         }
 
-        fn run_rejects_corrupted_cert_proof_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let rolling_state = rolling_state_from_asset(
-                load_embedded_recursive_chain_state_asset()
-                    .expect("recursive chain state asset should load"),
-            );
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let mut corrupted = step.certificate_proof.clone().into_vec();
-            corrupted[0] ^= 0xFF;
-            let snark_proof = wrap_snark_proof(corrupted);
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let result = prover.prove(
-                snark_proof,
-                step.message.as_ref(),
-                &avk,
-                &ctx.global,
-                &preimage,
-                &genesis_bootstrap(&ctx.asset_setup),
-                Some(&rolling_state),
-            );
-            assert!(
-                result.is_err(),
-                "prove should reject a corrupted certificate proof"
-            );
-
-            println!(
-                "[rejects-corrupted-cert-proof] {:.1}s",
-                t.elapsed().as_secs_f64()
-            );
-        }
-
-        fn run_rejects_mismatched_cert_message_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let rolling_state = rolling_state_from_asset(
-                load_embedded_recursive_chain_state_asset()
-                    .expect("recursive chain state asset should load"),
-            );
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut tampered_message = step.message;
-            tampered_message[0] ^= 0xFF;
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let result = prover.prove(
-                snark_proof,
-                tampered_message.as_ref(),
-                &avk,
-                &ctx.global,
-                &preimage,
-                &genesis_bootstrap(&ctx.asset_setup),
-                Some(&rolling_state),
-            );
-            assert!(
-                result.is_err(),
-                "prove should reject a tampered certificate message"
-            );
-
-            println!(
-                "[rejects-mismatched-cert-message] {:.1}s",
-                t.elapsed().as_secs_f64()
-            );
-        }
-
-        fn run_rejects_mismatched_avk_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let rolling_state = rolling_state_from_asset(
-                load_embedded_recursive_chain_state_asset()
-                    .expect("recursive chain state asset should load"),
-            );
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let mut tampered_root = step.aggregate_verification_key_merkle_root;
-            tampered_root[0] ^= 0xFF;
-            let wrong_avk = wrap_avk(&tampered_root);
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let result = prover.prove(
-                snark_proof,
-                step.message.as_ref(),
-                &wrong_avk,
-                &ctx.global,
-                &preimage,
-                &genesis_bootstrap(&ctx.asset_setup),
-                Some(&rolling_state),
-            );
-            assert!(
-                result.is_err(),
-                "prove should reject an AVK that does not match the one the proof committed to"
-            );
-
-            println!("[rejects-mismatched-avk] {:.1}s", t.elapsed().as_secs_f64());
-        }
-
-        fn run_rejects_corrupted_previous_ivc_proof_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let chain_state = load_embedded_recursive_chain_state_asset()
-                .expect("recursive chain state asset should load");
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let mut corrupted = chain_state.ivc_proof.into_vec();
-            corrupted[0] ^= 0xFF;
-            let rolling_state = IvcRollingState::new(
-                chain_state.state,
-                IvcProofBytes::new(corrupted),
-                chain_state.accumulator,
-                chain_state.genesis_signature,
-            );
-
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let result = prover.prove(
-                snark_proof,
-                step.message.as_ref(),
-                &avk,
-                &ctx.global,
-                &preimage,
-                &genesis_bootstrap(&ctx.asset_setup),
-                Some(&rolling_state),
-            );
-            assert!(
-                result.is_err(),
-                "prove should reject a corrupted previous IVC proof"
-            );
-
-            println!(
-                "[rejects-corrupted-prev-ivc-proof] {:.1}s",
-                t.elapsed().as_secs_f64()
-            );
-        }
-
-        fn run_rejects_mismatched_global_path(ctx: &SlowTestContext) {
-            let t = Instant::now();
-            let rolling_state = rolling_state_from_asset(
-                load_embedded_recursive_chain_state_asset()
-                    .expect("recursive chain state asset should load"),
-            );
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-
-            let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
-            let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
-            let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            let mut wrong_global = ctx.global.clone();
-            wrong_global.genesis_message =
-                MessageHash::from_field(BaseFieldElement::from(0xDEAD_BEEFu64).0);
-
-            let mut prover = IvcProver {
-                ivc_setup: Arc::clone(&ctx.ivc_setup),
-                rng: OsRng,
-            };
-            let result = prover.prove(
-                snark_proof,
-                step.message.as_ref(),
-                &avk,
-                &wrong_global,
-                &preimage,
-                &genesis_bootstrap(&ctx.asset_setup),
-                Some(&rolling_state),
-            );
-            assert!(
-                result.is_err(),
-                "prove should reject a global whose public inputs do not match the previous IVC proof"
-            );
-
-            println!(
-                "[rejects-mismatched-global] {:.1}s",
-                t.elapsed().as_secs_f64()
-            );
-        }
-
         #[test]
         fn prove_all_scenarios() {
             let t_setup = Instant::now();
@@ -1505,11 +1304,6 @@ mod tests {
             run_bootstrap_path(&ctx);
             run_next_epoch_path(&ctx);
             run_same_epoch_path(&ctx);
-            run_rejects_corrupted_cert_proof_path(&ctx);
-            run_rejects_mismatched_cert_message_path(&ctx);
-            run_rejects_mismatched_avk_path(&ctx);
-            run_rejects_corrupted_previous_ivc_proof_path(&ctx);
-            run_rejects_mismatched_global_path(&ctx);
         }
     }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -170,7 +170,7 @@ mod tests {
             },
             types::{
                 CertificateCircuitVerificationKeyRepresentation, EpochNumber,
-                IvcCircuitVerificationKeyRepresentation, StepCounter,
+                IvcCircuitVerificationKeyRepresentation, IvcProofBytes, StepCounter,
             },
         },
         proof_system::ivc_halo2_snark::prover_setup::IvcProverInputVerificationContext,
@@ -480,6 +480,173 @@ mod tests {
 
         let err = result
             .expect_err("prepare should reject a corrupted certificate proof")
+            .downcast::<IvcCircuitError>()
+            .expect("error should downcast to IvcCircuitError");
+        assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
+    }
+
+    #[test]
+    fn prepare_rejects_tampered_certificate_message() {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let step = load_embedded_following_certificate_in_epoch_asset()
+            .expect("same-epoch step output asset should load");
+
+        let (global, verification_context) = build_preparation_context();
+        let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
+        let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
+        let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
+        let rolling_state = IvcRollingState::new(
+            chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        );
+
+        let mut tampered_message = step.message;
+        tampered_message[0] ^= 0xFF;
+
+        let result = IvcProverInput::prepare(
+            &snark_proof,
+            &tampered_message,
+            &avk,
+            &global,
+            &protocol_message_preimage,
+            &rolling_state,
+            &verification_context,
+        );
+
+        let err = result
+            .expect_err("prepare should reject a tampered certificate message")
+            .downcast::<IvcCircuitError>()
+            .expect("error should downcast to IvcCircuitError");
+        assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
+    }
+
+    #[test]
+    fn prepare_rejects_mismatched_aggregate_verification_key() {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let step = load_embedded_following_certificate_in_epoch_asset()
+            .expect("same-epoch step output asset should load");
+
+        let (global, verification_context) = build_preparation_context();
+        let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
+        let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
+        let rolling_state = IvcRollingState::new(
+            chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        );
+
+        let mut tampered_root = step.aggregate_verification_key_merkle_root;
+        tampered_root[0] ^= 0xFF;
+
+        let result = IvcProverInput::prepare(
+            &snark_proof,
+            &step.message,
+            &wrap_avk(&tampered_root),
+            &global,
+            &protocol_message_preimage,
+            &rolling_state,
+            &verification_context,
+        );
+
+        // The step's Merkle-tree commitment is derived from the AVK root, so a tampered root is
+        // caught by the carry check against the rolling state, before the certificate proof is
+        // verified.
+        let err = result
+            .expect_err("prepare should reject an AVK the proof did not commit to")
+            .downcast::<IvcCircuitError>()
+            .expect("error should downcast to IvcCircuitError");
+        assert!(
+            matches!(
+                err,
+                IvcCircuitError::InvalidEpochTransition {
+                    kind:
+                        EpochTransitionErrorKind::RollingStateParametersDoesNotMatchProtocolMessage,
+                    ..
+                }
+            ),
+            "expected InvalidEpochTransition with RollingStateParametersDoesNotMatchProtocolMessage kind, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prepare_rejects_corrupted_previous_ivc_proof() {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let step = load_embedded_following_certificate_in_epoch_asset()
+            .expect("same-epoch step output asset should load");
+
+        let (global, verification_context) = build_preparation_context();
+        let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
+        let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
+        let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
+
+        let mut corrupted = chain_state.ivc_proof.into_vec();
+        corrupted[0] ^= 0xFF;
+        let rolling_state = IvcRollingState::new(
+            chain_state.state,
+            IvcProofBytes::new(corrupted),
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        );
+
+        let result = IvcProverInput::prepare(
+            &snark_proof,
+            &step.message,
+            &avk,
+            &global,
+            &protocol_message_preimage,
+            &rolling_state,
+            &verification_context,
+        );
+
+        let err = result
+            .expect_err("prepare should reject a corrupted previous IVC proof")
+            .downcast::<IvcCircuitError>()
+            .expect("error should downcast to IvcCircuitError");
+        assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
+    }
+
+    #[test]
+    fn prepare_rejects_mismatched_global() {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let step = load_embedded_following_certificate_in_epoch_asset()
+            .expect("same-epoch step output asset should load");
+
+        let (global, verification_context) = build_preparation_context();
+        let snark_proof = wrap_snark_proof(step.certificate_proof.clone().into_vec());
+        let avk = wrap_avk(&step.aggregate_verification_key_merkle_root);
+        let protocol_message_preimage = wrap_protocol_message_preimage(&step.message_preimage);
+        let rolling_state = IvcRollingState::new(
+            chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        );
+
+        // `Global` is part of the previous IVC proof's public inputs, so a chain whose genesis
+        // message differs from the one the proof committed to must not verify.
+        let mut mismatched_global = global.clone();
+        mismatched_global.genesis_message =
+            MessageHash::from_field(BaseFieldElement::from(0xDEAD_BEEFu64).0);
+
+        let result = IvcProverInput::prepare(
+            &snark_proof,
+            &step.message,
+            &avk,
+            &mismatched_global,
+            &protocol_message_preimage,
+            &rolling_state,
+            &verification_context,
+        );
+
+        let err = result
+            .expect_err("prepare should reject a global the previous IVC proof did not commit to")
             .downcast::<IvcCircuitError>()
             .expect("error should downcast to IvcCircuitError");
         assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -357,7 +357,7 @@ mod tests {
                 },
                 4,
             )
-            .expect("IvcSnarkProverSetup::load should succeed");
+            .expect("IvcSnarkProverSetup::build_for_test should succeed");
 
             assert!(
                 !setup.certificate_fixed_bases.is_empty(),
@@ -400,7 +400,7 @@ mod tests {
                 merkle_tree_depth,
                 RECURSIVE_CIRCUIT_DEGREE + 1,
             )
-            .expect("IvcSnarkProverSetup::load should succeed");
+            .expect("IvcSnarkProverSetup::build_for_test should succeed");
 
             let verification_context = load_embedded_verification_context_asset()
                 .expect("verification context asset should load");


### PR DESCRIPTION
## Content

`prove_all_scenarios` ran eight scenarios in one test to amortize a single setup. It costs 1393.9 s on the nightly and, with the two keygen-only `prover_setup` tests of the single-threaded `ivc-snark-sequential` group, forms an **1830 s serial tail, 59 % of the job's 3116 s test step**.

Splitting it naively costs more than it saves: at `user / real = 7.39` the test already saturates the runner's four vCPUs and peaks at 11.02 GiB against 16 GB, so the group must stay serial and each extra process adds 70-125 s. The split is paid for by removing proving instead — the five rejection scenarios generate no proofs, and the six `prove_with_transcript` calls cover only four distinct (transition type, transcript) pairs. Warm and local: **175.5 s to 126.0 s, −28 %**. On CI, normalised against the two untouched keygen-only tests of the same group, the two replacements cost 951 s against the monolith's 1264 s (**−313 s, −25 %**) taking the serial tail to 1408 s and the job's test step to 2348 s.

### Changes

- **Rejection scenarios to the fast tier** (`prover_input.rs`, `proof.rs`): four `run_rejects_*` helpers become `prepare` tests asserting typed `IvcCircuitError` variants instead of `is_err()`, at ~0.36 s on every PR rather than nightly only, each failed inside `prepare`, which since #3466 needs no SRS, keygen or cache. The fifth duplicated `prepare_rejects_invalid_snark_proof` and is deleted.
- **Monolith split, mature next-epoch proving removed** (`proof.rs`): `prove_bootstrap_produces_first_epoch_proof_and_rolling_state` (3 proofs) and `prove_same_epoch_produces_proof_without_rolling_state` (1 proof) share a plain `build_slow_test_context()`, no `OnceLock`, which amortizes nothing under nextest's process-per-test model. `run_next_epoch_path` adds no new pair, and `prepare_at_next_epoch_carries_lookahead_protocol_parameters` already pins its state and accumulator against the same asset.
- **Context decoupled from asset generation** (`proof.rs`): the slow context builds `Global` and the genesis bootstrap input from the committed genesis fixture rather than `AssetGenerationSetup`. No measurable wall-time change — setup spans 7.1-8.7 s for identical artifacts and the ~1.0 GB proving key deserialize dominates — so it is kept for the decoupling, not for speed.
- **Unchanged**: `.config/nextest.toml` and `filter-slow-tests.sh` match on module path, so the renamed tests stay grouped and watched. The coverage the reduction rests on still passes; restore a mature next-epoch proving case if production later couples transition type with accumulator provenance, public inputs or transcript selection.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Closes https://github.com/IntersectMBO/mithril/issues/3468

