### PR TITLE
ci: raise the wasm headless tests timeout to 15 minutes

### DIFF
--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -28,8 +28,8 @@ def run_headless_test():
     try:
         driver.get('http://localhost:8080/')
 
-        # Adjust the timeout to 10 minutes
-        wait = WebDriverWait(driver, 600)
+        # Adjust the timeout to 15 minutes
+        wait = WebDriverWait(driver, 900)
 
         # Wait until the div with id "tests_finished" is displayed
         tests_finished_element = wait.until(EC.presence_of_element_located((By.ID, "tests_finished")))


### PR DESCRIPTION
## Content

This PR includes a **fix for the flakiness of the wasm client CI test which fails with a Selenium timeout on the nightly runs**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

