### PR TITLE
feat(stm): add off circuit checks

### DIFF
--- a/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use ff::Field;
+use midnight_circuits::verifier::SelfEmulation;
 use midnight_proofs::poly::{CommitmentLabel, kzg::msm::DualMSM};
 
 use crate::{StmResult, circuits::halo2_ivc::errors::IvcCircuitError};
@@ -77,6 +78,25 @@ pub(crate) fn check_dual_msm_matches_fixed_bases(
             _ => continue,
         };
         if fixed_bases.get(&name) != Some(base) {
+            return Err(IvcCircuitError::MsmFixedBasesNamesMismatch { name }.into());
+        }
+    }
+    Ok(())
+}
+
+/// Checks that every fixed-base name the `accumulator`` references is present in `fixed_bases`.
+/// Pre-flight check for `Accumulator::check`, which panics (not returns false) on a missing name.
+pub(crate) fn check_accumulator_fixed_bases_present<S: SelfEmulation>(
+    accumulator: &Accumulator<S>,
+    fixed_bases: &BTreeMap<String, S::C>,
+) -> StmResult<()> {
+    let names = accumulator
+        .lhs()
+        .fixed_base_scalars()
+        .into_keys()
+        .chain(accumulator.rhs().fixed_base_scalars().into_keys());
+    for name in names {
+        if !fixed_bases.contains_key(&name) {
             return Err(IvcCircuitError::MsmFixedBasesNamesMismatch { name }.into());
         }
     }

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -72,6 +72,12 @@ pub enum EpochTransitionErrorKind {
     #[error("rolling state parameters do not match the current protocol message parameters")]
     RollingStateParametersDoesNotMatchProtocolMessage,
 
+    /// The genesis preimage's lookahead (next merkle tree commitment / epoch) does not match the
+    /// first real certificate's protocol message. The mismatch is against the genesis bootstrap's
+    /// own announced values.
+    #[error("genesis lookahead parameters do not match the first certificate's protocol message")]
+    GenesisLookaheadDoesNotMatchProtocolMessage,
+
     /// Off-circuit step transition: the chain's epoch would overflow u64.
     #[error("Epoch overflow advancing past the last committed epoch")]
     EpochOverflow,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_construction.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_construction.rs
@@ -1,11 +1,16 @@
 //! Tests that `trivial_accumulator` has the expected structure, verifiable through
 //! its public-input encoding.
 
+use std::collections::BTreeMap;
+
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator,
-    accumulator::{check_dual_msm_matches_fixed_bases, trivial_accumulator},
+    AssignedAccumulator, EmulatedCurve,
+    accumulator::{
+        check_accumulator_fixed_bases_present, check_dual_msm_matches_fixed_bases,
+        trivial_accumulator,
+    },
     errors::IvcCircuitError,
     tests::common::{
         asset_readers::{
@@ -95,4 +100,35 @@ fn wrong_prefix_for_fixed_bases_fails_check_for_dual_msm_names() {
         ivc_error,
         IvcCircuitError::MsmFixedBasesNamesMismatch { .. }
     ));
+}
+
+#[test]
+fn missing_fixed_base_name_fails_check_for_accumulator_names() {
+    let accumulator = trivial_accumulator(&["a".to_string(), "b".to_string()]);
+
+    let fixed_bases: BTreeMap<String, EmulatedCurve> =
+        BTreeMap::from([("a".to_string(), EmulatedCurve::default())]);
+
+    let err = check_accumulator_fixed_bases_present(&accumulator, &fixed_bases)
+        .expect_err("a fixed base missing from the map should be rejected");
+    let ivc_error = err
+        .downcast::<IvcCircuitError>()
+        .expect("error chain should carry IvcCircuitError");
+    assert!(matches!(
+        ivc_error,
+        IvcCircuitError::MsmFixedBasesNamesMismatch { name } if name == "b"
+    ));
+}
+
+#[test]
+fn all_fixed_base_names_present_succeeds_for_accumulator_names() {
+    let accumulator = trivial_accumulator(&["a".to_string(), "b".to_string()]);
+
+    let fixed_bases: BTreeMap<String, EmulatedCurve> = BTreeMap::from([
+        ("a".to_string(), EmulatedCurve::default()),
+        ("b".to_string(), EmulatedCurve::default()),
+    ]);
+
+    check_accumulator_fixed_bases_present(&accumulator, &fixed_bases)
+        .expect("every fixed base name referenced by the accumulator is present in the map");
 }

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -5,12 +5,14 @@
 
 use ff::Field;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{BaseFieldElement, StmResult};
 
 use super::{
     NativeField, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE, Value,
 };
-use crate::BaseFieldElement;
 
 /// Circuit-boundary alias for Midnight proofs' `Value<T>` witness wrapper.
 pub(crate) type CircuitValue<T> = Value<T>;
@@ -148,6 +150,15 @@ impl ProtocolMessagePreimage {
 impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
     fn from(bytes: [u8; PREIMAGE_SIZE]) -> Self {
         Self(bytes)
+    }
+}
+
+impl TryInto<MessageHash> for &ProtocolMessagePreimage {
+    type Error = anyhow::Error;
+    fn try_into(self) -> StmResult<MessageHash> {
+        let preimage_hash: [u8; 32] = Sha256::digest(self.0).into();
+        let message_field_elem = BaseFieldElement::from_raw(&preimage_hash)?.0;
+        Ok(MessageHash::from_field(message_field_elem))
     }
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -153,10 +153,10 @@ impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
     }
 }
 
-impl TryInto<MessageHash> for &ProtocolMessagePreimage {
+impl TryFrom<&ProtocolMessagePreimage> for MessageHash {
     type Error = anyhow::Error;
-    fn try_into(self) -> StmResult<MessageHash> {
-        let preimage_hash: [u8; 32] = Sha256::digest(self.0).into();
+    fn try_from(preimage: &ProtocolMessagePreimage) -> StmResult<Self> {
+        let preimage_hash: [u8; 32] = Sha256::digest(preimage.0).into();
         let message_field_elem = BaseFieldElement::from_raw(&preimage_hash)?.0;
         Ok(MessageHash::from_field(message_field_elem))
     }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/errors.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/errors.rs
@@ -32,4 +32,12 @@ pub(crate) enum IvcProofError {
         "IVC proof rejected: the message used to create the proof is different from the input message"
     )]
     InvalidMessage,
+
+    /// The protocol parameters having been changed
+    #[error("The protocol parameters were changed which would result in an invalid proof")]
+    ProtocolParametersChanged,
+
+    /// The message supplied to the clerk does not match the protocol message preimage
+    #[error("The message supplied to the clerk does not match the protocol message preimage")]
+    MessagePreimageMismatch,
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/errors.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/errors.rs
@@ -40,4 +40,10 @@ pub(crate) enum IvcProofError {
     /// The message supplied to the clerk does not match the protocol message preimage
     #[error("The message supplied to the clerk does not match the protocol message preimage")]
     MessagePreimageMismatch,
+
+    /// New accumulator created from the previous ivc proof and new certificate proof does not verify
+    #[error(
+        "New accumulator created from the previous ivc proof and new certificate proof does not verify"
+    )]
+    InvalidNextAccumulator,
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
@@ -28,7 +28,7 @@ pub(crate) trait IvcChainProver<D: MembershipDigest> {
 
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait IvcOffCircuitChecker: Debug {
-    /// Orchestrates the three category checks below. The only method `Clerk` calls.
+    /// Orchestrates the three category checks below.
     fn check(
         &self,
         msg: &[u8],
@@ -36,7 +36,7 @@ pub(crate) trait IvcOffCircuitChecker: Debug {
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()>;
 
-    /// Genesis vk present + structurally valid, genesis signature present + preimage sized
+    /// Checks: genesis vk present + structurally valid, genesis signature present + preimage sized
     /// correctly, genesis signature cryptographically verifies.
     fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()>;
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
@@ -26,8 +26,17 @@ pub(crate) trait IvcChainProver<D: MembershipDigest> {
     ) -> StmResult<(IvcProof<Blake2b256>, Option<IvcRollingState>)>;
 }
 
+/// A trait that represents the off-circuit (CPU-side) validation checks run against an incoming
+/// certificate and its ancillary data before the recursive SNARK proving path begins. Rejecting
+/// an invalid request here avoids paying for certificate/IVC proof generation on a request that
+/// could never verify.
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait IvcOffCircuitChecker<D: MembershipDigest>: Debug {
+    /// Runs off-circuit checks that mirror what the recursive circuit itself enforces in-circuit,
+    /// validating the caller-supplied certificate message, ancillary data, and aggregate
+    /// verification key before any of it is trusted for proof generation.
+    ///
+    /// Returns `Ok(())` when every check passes, otherwise the first failing check's error.
     fn off_circuit_check(
         &self,
         msg: &[u8],

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use midnight_proofs::transcript::Blake2b256;
 
 use crate::{
-    AncillaryProofInput, MembershipDigest, StmResult,
+    AggregateVerificationKeyForSnark, AncillaryProofInput, MembershipDigest, StmResult,
     circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey,
     proof_system::{
         IvcRollingState,
@@ -27,33 +27,11 @@ pub(crate) trait IvcChainProver<D: MembershipDigest> {
 }
 
 #[cfg_attr(test, mockall::automock)]
-pub(crate) trait IvcOffCircuitChecker: Debug {
-    /// Orchestrates the three category checks below.
+pub(crate) trait IvcOffCircuitChecker<D: MembershipDigest>: Debug {
     fn off_circuit_check(
         &self,
         msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
-        ancillary_input: &AncillaryProofInput,
-    ) -> StmResult<()>;
-
-    /// Checks: genesis vk present + structurally valid, genesis signature present + preimage sized
-    /// correctly, genesis signature cryptographically verifies.
-    fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()>;
-
-    /// If there's an existing rolling state: not genesis-shaped, epoch transition valid,
-    /// certificate/state consistency, protocol parameters unchanged. No-ops when there isn't one.
-    fn check_rolling_state(
-        &self,
-        msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
-        ancillary_input: &AncillaryProofInput,
-    ) -> StmResult<()>;
-
-    /// Protocol message preimage is the right size, and hashes to the certificate's message.
-    fn check_protocol_message(
-        &self,
-        msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()>;
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
@@ -29,7 +29,7 @@ pub(crate) trait IvcChainProver<D: MembershipDigest> {
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait IvcOffCircuitChecker: Debug {
     /// Orchestrates the three category checks below.
-    fn check(
+    fn off_circuit_check(
         &self,
         msg: &[u8],
         aggregate_verification_key_merkle_root: &[u8],

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/interface.rs
@@ -1,7 +1,9 @@
+use std::fmt::Debug;
+
 use midnight_proofs::transcript::Blake2b256;
 
 use crate::{
-    MembershipDigest, StmResult,
+    AncillaryProofInput, MembershipDigest, StmResult,
     circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey,
     proof_system::{
         IvcRollingState,
@@ -22,4 +24,36 @@ pub(crate) trait IvcChainProver<D: MembershipDigest> {
         &mut self,
         step_bundle: IvcChainStepBundle<D>,
     ) -> StmResult<(IvcProof<Blake2b256>, Option<IvcRollingState>)>;
+}
+
+#[cfg_attr(test, mockall::automock)]
+pub(crate) trait IvcOffCircuitChecker: Debug {
+    /// Orchestrates the three category checks below. The only method `Clerk` calls.
+    fn check(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()>;
+
+    /// Genesis vk present + structurally valid, genesis signature present + preimage sized
+    /// correctly, genesis signature cryptographically verifies.
+    fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()>;
+
+    /// If there's an existing rolling state: not genesis-shaped, epoch transition valid,
+    /// certificate/state consistency, protocol parameters unchanged. No-ops when there isn't one.
+    fn check_rolling_state(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()>;
+
+    /// Protocol message preimage is the right size, and hashes to the certificate's message.
+    fn check_protocol_message(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()>;
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
@@ -10,9 +10,10 @@ mod prover_setup;
 mod rolling_state;
 mod verifier_setup;
 
-pub(crate) use interface::IvcChainProver;
+pub(crate) use interface::{IvcChainProver, IvcOffCircuitChecker};
 #[cfg(test)]
-pub(crate) use interface::MockIvcChainProver;
+pub(crate) use interface::{MockIvcChainProver, MockIvcOffCircuitChecker};
+pub(crate) use off_circuit_checker::RealIvcOffCircuitChecker;
 pub(crate) use proof::{IvcChainStepBundle, IvcProof, IvcProver};
 #[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_input::IvcProverInput;

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
@@ -2,6 +2,7 @@
 
 mod errors;
 mod interface;
+mod off_circuit_checker;
 mod proof;
 mod prover_input;
 mod prover_input_helpers;
@@ -19,5 +20,5 @@ pub(crate) use prover_input::IvcProverInput;
 pub(crate) use prover_input_helpers::tests::build_standard_rolling_state;
 #[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_setup::IvcProverSetup;
-pub(crate) use rolling_state::IvcRollingState;
+pub(crate) use rolling_state::{IvcRollingState, IvcTransitionType};
 pub(crate) use verifier_setup::{IvcVerifierData, IvcVerifierSetup};

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
@@ -13,7 +13,7 @@ mod verifier_setup;
 pub(crate) use interface::{IvcChainProver, IvcOffCircuitChecker};
 #[cfg(test)]
 pub(crate) use interface::{MockIvcChainProver, MockIvcOffCircuitChecker};
-pub(crate) use off_circuit_checker::RealIvcOffCircuitChecker;
+pub(crate) use off_circuit_checker::MithrilIvcOffCircuitChecker;
 pub(crate) use proof::{IvcChainStepBundle, IvcProof, IvcProver};
 #[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_input::IvcProverInput;

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -1,0 +1,101 @@
+use anyhow::anyhow;
+
+use crate::{
+    AggregationError, AncillaryProofInput, BaseFieldElement, StmResult,
+    circuits::halo2_ivc::{PREIMAGE_SIZE, ProtocolMessagePreimage, types::MessageHash},
+    proof_system::{
+        IvcRollingState,
+        halo2_ivc_snark::{
+            IvcTransitionType, errors::IvcProofError, interface::IvcOffCircuitChecker,
+            proof::IvcGenesisBootstrapInput,
+        },
+    },
+};
+
+#[derive(Debug)]
+struct RealIvcOffCircuitChecker;
+
+impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
+    fn check(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()> {
+        todo!()
+    }
+
+    fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()> {
+        let genesis_data = ancillary_input.genesis_data();
+
+        let genesis_verifying_key = genesis_data
+            .genesis_schnorr_verification_key()
+            .cloned()
+            .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
+        genesis_verifying_key.is_valid()?;
+
+        let genesis_message: MessageHash = genesis_data.genesis_message_preimage().try_into()?;
+
+        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+        genesis_bootstrap.genesis_signature.verify(
+            &[BaseFieldElement::from(genesis_message.as_field())],
+            &genesis_verifying_key,
+        )?;
+        Ok(())
+    }
+
+    fn check_rolling_state(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()> {
+        let rolling_state = ancillary_input
+            .prover_data()
+            .and_then(|prover_data| prover_data.as_ivc_rolling_state());
+
+        ensure_advanceable_rolling_state(rolling_state)?;
+
+        let Some(rolling_state) = rolling_state else {
+            return Ok(());
+        };
+
+        let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
+        let preimage = ProtocolMessagePreimage(preimage_bytes);
+
+        let (transition_type, certificate_message_hash, certificate_merkle_tree_commitment) =
+            rolling_state.validate_transition(
+                &preimage,
+                aggregate_verification_key_merkle_root,
+                msg,
+            )?;
+        rolling_state.assert_protocol_parameters_unchanged()?;
+
+        Ok(())
+    }
+
+    fn check_protocol_message(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key_merkle_root: &[u8],
+        ancillary_input: &AncillaryProofInput,
+    ) -> StmResult<()> {
+        todo!()
+    }
+}
+
+/// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
+///
+/// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
+/// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
+/// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
+/// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
+/// both-`None` misuses are now unrepresentable.
+pub(crate) fn ensure_advanceable_rolling_state(
+    rolling_state: Option<&IvcRollingState>,
+) -> StmResult<()> {
+    if rolling_state.is_some_and(|rs| rs.is_genesis()) {
+        return Err(IvcProofError::InvalidProvingContext.into());
+    }
+    Ok(())
+}

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -19,7 +19,7 @@ use crate::{
 pub(crate) struct RealIvcOffCircuitChecker;
 
 impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
-    fn check(
+    fn off_circuit_check(
         &self,
         msg: &[u8],
         aggregate_verification_key_merkle_root: &[u8],
@@ -135,6 +135,7 @@ mod tests {
         },
         signature_scheme::{
             BaseFieldElement, ScalarFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
+            StandardSchnorrSignature,
         },
     };
 
@@ -151,14 +152,31 @@ mod tests {
         )
     }
 
+    fn genesis_only_ancillary_input(genesis_data: AncillaryGenesisData) -> AncillaryProofInput {
+        AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE])
+    }
+
+    /// Builds a signature and its matching verification key from a seed, both over the same
+    /// synthetic message. Convenient for tests that only need one of the two.
+    fn synthetic_signature_and_key(
+        seed: [u8; 32],
+    ) -> (StandardSchnorrSignature, SchnorrVerificationKey) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let signing_key = SchnorrSigningKey::generate(&mut rng);
+        let signature = signing_key
+            .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
+            .expect("sign_standard should succeed for a synthetic message");
+        let verification_key = SchnorrVerificationKey::new_from_signing_key(signing_key);
+        (signature, verification_key)
+    }
+
     mod check_genesis {
         use super::*;
 
         #[test]
         fn rejects_missing_genesis_verification_key() {
             let genesis_data = AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, None);
-            let ancillary_input =
-                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+            let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
             let err = RealIvcOffCircuitChecker
                 .check_genesis(&ancillary_input)
@@ -177,8 +195,7 @@ mod tests {
             ));
             let genesis_data =
                 AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, Some(invalid_key));
-            let ancillary_input =
-                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+            let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
             RealIvcOffCircuitChecker
                 .check_genesis(&ancillary_input)
@@ -187,18 +204,14 @@ mod tests {
 
         #[test]
         fn rejects_missing_genesis_signature() {
-            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-            let signing_key = SchnorrSigningKey::generate(&mut rng);
-            let genesis_verification_key =
-                SchnorrVerificationKey::new_from_signing_key(signing_key);
+            let (_, genesis_verification_key) = synthetic_signature_and_key([0u8; 32]);
 
             let genesis_data = AncillaryGenesisData::new(
                 vec![0u8; PREIMAGE_SIZE],
                 None,
                 Some(genesis_verification_key),
             );
-            let ancillary_input =
-                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+            let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
             let err = RealIvcOffCircuitChecker
                 .check_genesis(&ancillary_input)
@@ -214,20 +227,14 @@ mod tests {
         fn rejects_genesis_signature_over_wrong_message() {
             let genesis_fixture = load_embedded_genesis_benchmark_fixture()
                 .expect("genesis benchmark fixture should load");
-
-            let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
-            let unrelated_signing_key = SchnorrSigningKey::generate(&mut rng);
-            let wrong_signature = unrelated_signing_key
-                .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
-                .expect("sign_standard should succeed for a synthetic message");
+            let (wrong_signature, _) = synthetic_signature_and_key([1u8; 32]);
 
             let genesis_data = AncillaryGenesisData::new(
                 genesis_fixture.genesis_protocol_message_preimage.to_vec(),
                 Some(wrong_signature),
                 Some(genesis_fixture.genesis_verification_key),
             );
-            let ancillary_input =
-                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+            let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
             RealIvcOffCircuitChecker
                 .check_genesis(&ancillary_input)
@@ -244,8 +251,7 @@ mod tests {
                 Some(genesis_fixture.genesis_signature),
                 Some(genesis_fixture.genesis_verification_key),
             );
-            let ancillary_input =
-                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+            let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
             RealIvcOffCircuitChecker
                 .check_genesis(&ancillary_input)
@@ -273,11 +279,7 @@ mod tests {
 
         #[test]
         fn rejects_genesis_shaped_existing_rolling_state() {
-            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-            let signing_key = SchnorrSigningKey::generate(&mut rng);
-            let genesis_signature = signing_key
-                .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
-                .expect("genesis signature should be produced");
+            let (genesis_signature, _) = synthetic_signature_and_key([0u8; 32]);
             let genesis_rolling_state = IvcRollingState::genesis(genesis_signature, &[]);
 
             let ancillary_input = AncillaryProofInput::new(
@@ -431,7 +433,7 @@ mod tests {
         );
 
         RealIvcOffCircuitChecker
-            .check(
+            .off_circuit_check(
                 &step.message,
                 &step.aggregate_verification_key_merkle_root,
                 &ancillary_input,

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -13,6 +13,8 @@ use crate::{
     },
 };
 
+/// Production implementation of `IvcOffCircuitChecker`. Stateless: every check is a pure
+/// function of its arguments, so no setup or trusted material is needed to construct one.
 #[derive(Debug)]
 pub(crate) struct RealIvcOffCircuitChecker;
 
@@ -99,18 +101,341 @@ impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
     }
 }
 
-/// Asserts that the rolling state's protocol parameters have not diverged from their
-/// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
-/// carries the bootstrap value, so genesis is exempt; every step after that must have the two
-/// equal, since changing protocol parameters between epochs isn't currently supported.
-pub(crate) fn assert_protocol_parameters_unchanged(
-    rolling_state: &IvcRollingState,
-) -> StmResult<()> {
-    if !rolling_state.is_genesis()
-        && rolling_state.state().protocol_parameters
-            != rolling_state.state().next_protocol_parameters
-    {
-        return Err(IvcProofError::ProtocolParametersChanged.into());
+impl RealIvcOffCircuitChecker {
+    /// Asserts that the rolling state's protocol parameters have not diverged from their
+    /// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
+    /// carries the bootstrap value, so genesis is exempt; every step after that must have the two
+    /// equal, since changing protocol parameters between epochs isn't currently supported.
+    pub(crate) fn assert_protocol_parameters_unchanged(
+        rolling_state: &IvcRollingState,
+    ) -> StmResult<()> {
+        if !rolling_state.is_genesis()
+            && rolling_state.state().protocol_parameters
+                != rolling_state.state().next_protocol_parameters
+        {
+            return Err(IvcProofError::ProtocolParametersChanged.into());
+        }
+        Ok(())
     }
-    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    use crate::{
+        AncillaryGenesisData, AncillaryProverData,
+        circuits::halo2_ivc::{
+            tests::common::asset_readers::{
+                load_embedded_following_certificate_in_epoch_asset,
+                load_embedded_genesis_benchmark_fixture, load_embedded_recursive_chain_state_asset,
+            },
+            types::ProtocolParametersHash,
+        },
+        signature_scheme::{
+            BaseFieldElement, ScalarFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
+        },
+    };
+
+    use super::*;
+
+    fn rolling_state_from_chain_state() -> IvcRollingState {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        IvcRollingState::new(
+            chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        )
+    }
+
+    mod check_genesis {
+        use super::*;
+
+        #[test]
+        fn rejects_missing_genesis_verification_key() {
+            let genesis_data = AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, None);
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+
+            let err = RealIvcOffCircuitChecker
+                .check_genesis(&ancillary_input)
+                .expect_err("missing genesis verification key must be rejected");
+
+            assert_eq!(
+                err.downcast_ref::<AggregationError>(),
+                Some(&AggregationError::MissingGenesisVerificationKey)
+            );
+        }
+
+        #[test]
+        fn rejects_invalid_genesis_verification_key() {
+            let invalid_key = SchnorrVerificationKey::new_from_signing_key(SchnorrSigningKey(
+                ScalarFieldElement::get_zero(),
+            ));
+            let genesis_data =
+                AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, Some(invalid_key));
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+
+            RealIvcOffCircuitChecker
+                .check_genesis(&ancillary_input)
+                .expect_err("invalid genesis verification key must be rejected");
+        }
+
+        #[test]
+        fn rejects_missing_genesis_signature() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let signing_key = SchnorrSigningKey::generate(&mut rng);
+            let genesis_verification_key =
+                SchnorrVerificationKey::new_from_signing_key(signing_key);
+
+            let genesis_data = AncillaryGenesisData::new(
+                vec![0u8; PREIMAGE_SIZE],
+                None,
+                Some(genesis_verification_key),
+            );
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+
+            let err = RealIvcOffCircuitChecker
+                .check_genesis(&ancillary_input)
+                .expect_err("missing genesis signature must be rejected");
+
+            assert_eq!(
+                err.root_cause().to_string(),
+                "Missing genesis Schnorr signature."
+            );
+        }
+
+        #[test]
+        fn rejects_genesis_signature_over_wrong_message() {
+            let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+                .expect("genesis benchmark fixture should load");
+
+            let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+            let unrelated_signing_key = SchnorrSigningKey::generate(&mut rng);
+            let wrong_signature = unrelated_signing_key
+                .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
+                .expect("sign_standard should succeed for a synthetic message");
+
+            let genesis_data = AncillaryGenesisData::new(
+                genesis_fixture.genesis_protocol_message_preimage.to_vec(),
+                Some(wrong_signature),
+                Some(genesis_fixture.genesis_verification_key),
+            );
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+
+            RealIvcOffCircuitChecker
+                .check_genesis(&ancillary_input)
+                .expect_err("a genesis signature over the wrong message must be rejected");
+        }
+
+        #[test]
+        fn accepts_valid_genesis_data() {
+            let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+                .expect("genesis benchmark fixture should load");
+
+            let genesis_data = AncillaryGenesisData::new(
+                genesis_fixture.genesis_protocol_message_preimage.to_vec(),
+                Some(genesis_fixture.genesis_signature),
+                Some(genesis_fixture.genesis_verification_key),
+            );
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, vec![0u8; PREIMAGE_SIZE]);
+
+            RealIvcOffCircuitChecker
+                .check_genesis(&ancillary_input)
+                .expect("consistent genesis data should pass");
+        }
+    }
+
+    mod check_rolling_state {
+        use crate::circuits::halo2_ivc::state::State;
+
+        use super::*;
+
+        #[test]
+        fn accepts_when_no_rolling_state() {
+            let ancillary_input = AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::dummy(),
+                vec![0u8; PREIMAGE_SIZE],
+            );
+
+            RealIvcOffCircuitChecker
+                .check_rolling_state(&[0u8; 32], &[0u8; 32], &ancillary_input)
+                .expect("no rolling state means nothing to check here");
+        }
+
+        #[test]
+        fn rejects_genesis_shaped_existing_rolling_state() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let signing_key = SchnorrSigningKey::generate(&mut rng);
+            let genesis_signature = signing_key
+                .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
+                .expect("genesis signature should be produced");
+            let genesis_rolling_state = IvcRollingState::genesis(genesis_signature, &[]);
+
+            let ancillary_input = AncillaryProofInput::new(
+                Some(AncillaryProverData::IvcSnark(genesis_rolling_state)),
+                AncillaryGenesisData::dummy(),
+                vec![0u8; PREIMAGE_SIZE],
+            );
+
+            RealIvcOffCircuitChecker
+                .check_rolling_state(&[0u8; 32], &[0u8; 32], &ancillary_input)
+                .expect_err("a genesis-shaped existing rolling state must be rejected");
+        }
+
+        #[test]
+        fn accepts_consistent_same_epoch_step() {
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+            let ancillary_input = AncillaryProofInput::new(
+                Some(AncillaryProverData::IvcSnark(
+                    rolling_state_from_chain_state(),
+                )),
+                AncillaryGenesisData::dummy(),
+                step.message_preimage.to_vec(),
+            );
+
+            RealIvcOffCircuitChecker
+                .check_rolling_state(
+                    &step.message,
+                    &step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect("consistent same-epoch step should pass");
+        }
+
+        #[test]
+        fn rejects_when_protocol_parameters_diverged() {
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+            let chain_state = load_embedded_recursive_chain_state_asset()
+                .expect("recursive chain state asset should load");
+
+            // Only current `protocol_parameters` diverges from `next_protocol_parameters`;
+            // assert_correct_parameters never checks the current value, so this reaches the
+            // protocol-parameters-unchanged check specifically.
+            let diverged_state = State::new(
+                chain_state.state.step_counter,
+                chain_state.state.message,
+                chain_state.state.merkle_tree_commitment,
+                chain_state.state.next_merkle_tree_commitment,
+                ProtocolParametersHash::from_field(BaseFieldElement::from(999u64).0),
+                chain_state.state.next_protocol_parameters,
+                chain_state.state.current_epoch,
+            );
+            let rolling_state = IvcRollingState::new(
+                diverged_state,
+                chain_state.ivc_proof,
+                chain_state.accumulator,
+                chain_state.genesis_signature,
+            );
+            let ancillary_input = AncillaryProofInput::new(
+                Some(AncillaryProverData::IvcSnark(rolling_state)),
+                AncillaryGenesisData::dummy(),
+                step.message_preimage.to_vec(),
+            );
+
+            RealIvcOffCircuitChecker
+                .check_rolling_state(
+                    &step.message,
+                    &step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect_err("diverged protocol parameters must be rejected");
+        }
+    }
+
+    mod check_protocol_message {
+        use super::*;
+
+        #[test]
+        fn rejects_wrong_size_preimage() {
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+            let ancillary_input =
+                AncillaryProofInput::new(None, AncillaryGenesisData::dummy(), vec![0u8; 3]);
+
+            RealIvcOffCircuitChecker
+                .check_protocol_message(
+                    &step.message,
+                    &step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect_err("wrong-size preimage must be rejected");
+        }
+
+        #[test]
+        fn rejects_mismatched_message_hash() {
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+            let ancillary_input = AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::dummy(),
+                vec![0u8; PREIMAGE_SIZE],
+            );
+
+            RealIvcOffCircuitChecker
+                .check_protocol_message(
+                    &step.message,
+                    &step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect_err("mismatched preimage must be rejected");
+        }
+
+        #[test]
+        fn accepts_matching_message_hash() {
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+            let ancillary_input = AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::dummy(),
+                step.message_preimage.to_vec(),
+            );
+
+            RealIvcOffCircuitChecker
+                .check_protocol_message(
+                    &step.message,
+                    &step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect("consistent message/preimage should pass");
+        }
+    }
+
+    #[test]
+    fn check_accepts_a_fully_consistent_same_epoch_request() {
+        let step = load_embedded_following_certificate_in_epoch_asset()
+            .expect("same-epoch step output asset should load");
+        let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+            .expect("genesis benchmark fixture should load");
+        let genesis_data = AncillaryGenesisData::new(
+            genesis_fixture.genesis_protocol_message_preimage.to_vec(),
+            Some(genesis_fixture.genesis_signature),
+            Some(genesis_fixture.genesis_verification_key),
+        );
+        let ancillary_input = AncillaryProofInput::new(
+            Some(AncillaryProverData::IvcSnark(
+                rolling_state_from_chain_state(),
+            )),
+            genesis_data,
+            step.message_preimage.to_vec(),
+        );
+
+        RealIvcOffCircuitChecker
+            .check(
+                &step.message,
+                &step.aggregate_verification_key_merkle_root,
+                &ancillary_input,
+            )
+            .expect("a fully consistent request should pass every check");
+    }
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -78,8 +78,7 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
                     == genesis_preimage.next_merkle_tree_commitment();
             if !matches_genesis_lookahead {
                 return Err(IvcCircuitError::InvalidEpochTransition {
-                    kind:
-                        EpochTransitionErrorKind::RollingStateParametersDoesNotMatchProtocolMessage,
+                    kind: EpochTransitionErrorKind::GenesisLookaheadDoesNotMatchProtocolMessage,
                     last_committed_epoch: genesis_epoch.as_u64(),
                 }
                 .into());
@@ -105,6 +104,7 @@ mod tests {
     use crate::{
         AncillaryGenesisData, AncillaryProverData, MithrilMembershipDigest,
         circuits::halo2_ivc::{
+            state::State,
             tests::common::asset_readers::{
                 load_embedded_first_certificate_in_epoch_asset,
                 load_embedded_following_certificate_in_epoch_asset,
@@ -127,6 +127,29 @@ mod tests {
             .expect("recursive chain state asset should load");
         IvcRollingState::new(
             chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        )
+    }
+
+    // Builds a rolling state whose `protocol_parameters` diverges from `next_protocol_parameters`
+    // (as if an earlier certificate had announced a parameter change for the following epoch),
+    // otherwise carrying the same fields as the embedded recursive chain state asset.
+    fn diverged_rolling_state() -> IvcRollingState {
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let diverged_state = State::new(
+            chain_state.state.step_counter,
+            chain_state.state.message,
+            chain_state.state.merkle_tree_commitment,
+            chain_state.state.next_merkle_tree_commitment,
+            ProtocolParametersHash::from_field(BaseFieldElement::from(999u64).0),
+            chain_state.state.next_protocol_parameters,
+            chain_state.state.current_epoch,
+        );
+        IvcRollingState::new(
+            diverged_state,
             chain_state.ivc_proof,
             chain_state.accumulator,
             chain_state.genesis_signature,
@@ -261,11 +284,49 @@ mod tests {
                     "consistent genesis data paired with a matching first certificate should pass",
                 );
         }
+
+        #[test]
+        fn rejects_first_certificate_with_wrong_epoch_or_avk() {
+            let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+                .expect("genesis benchmark fixture should load");
+            let mismatched_step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
+
+            let genesis_data = AncillaryGenesisData::new(
+                genesis_fixture.genesis_protocol_message_preimage.to_vec(),
+                Some(genesis_fixture.genesis_signature),
+                Some(genesis_fixture.genesis_verification_key),
+            );
+            let ancillary_input = AncillaryProofInput::new(
+                None,
+                genesis_data,
+                mismatched_step.message_preimage.to_vec(),
+            );
+
+            let err = MithrilIvcOffCircuitChecker
+                .off_circuit_check(
+                    &mismatched_step.message,
+                    &avk_with_root(mismatched_step.aggregate_verification_key_merkle_root),
+                    &ancillary_input,
+                )
+                .expect_err(
+                    "a certificate not matching genesis's announced epoch/AVK must be rejected",
+                );
+
+            let circuit_error = err
+                .downcast_ref::<IvcCircuitError>()
+                .expect("error chain should carry IvcCircuitError");
+            assert!(matches!(
+                circuit_error,
+                IvcCircuitError::InvalidEpochTransition {
+                    kind: EpochTransitionErrorKind::GenesisLookaheadDoesNotMatchProtocolMessage,
+                    ..
+                }
+            ));
+        }
     }
 
     mod check_rolling_state {
-        use crate::circuits::halo2_ivc::state::State;
-
         use super::*;
 
         #[test]
@@ -306,29 +367,6 @@ mod tests {
                     "consistent same-epoch step should pass every check, including the \
                      message-hash match",
                 );
-        }
-
-        // Builds a rolling state whose `protocol_parameters` diverges from `next_protocol_parameters`
-        // (as if an earlier certificate had announced a parameter change for the following epoch),
-        // otherwise carrying the same fields as the embedded recursive chain state asset.
-        fn diverged_rolling_state() -> IvcRollingState {
-            let chain_state = load_embedded_recursive_chain_state_asset()
-                .expect("recursive chain state asset should load");
-            let diverged_state = State::new(
-                chain_state.state.step_counter,
-                chain_state.state.message,
-                chain_state.state.merkle_tree_commitment,
-                chain_state.state.next_merkle_tree_commitment,
-                ProtocolParametersHash::from_field(BaseFieldElement::from(999u64).0),
-                chain_state.state.next_protocol_parameters,
-                chain_state.state.current_epoch,
-            );
-            IvcRollingState::new(
-                diverged_state,
-                chain_state.ivc_proof,
-                chain_state.accumulator,
-                chain_state.genesis_signature,
-            )
         }
 
         #[test]

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -1,8 +1,8 @@
 use anyhow::anyhow;
 
 use crate::{
-    AggregateVerificationKeyForSnark, AggregationError, AncillaryProofInput, BaseFieldElement,
-    MembershipDigest, StmResult,
+    AggregateVerificationKeyForSnark, AggregationError, AncillaryGenesisData, AncillaryProofInput,
+    BaseFieldElement, MembershipDigest, SchnorrVerificationKey, StmResult,
     circuits::halo2_ivc::{
         PREIMAGE_SIZE, ProtocolMessagePreimage,
         errors::{EpochTransitionErrorKind, IvcCircuitError},
@@ -31,15 +31,8 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()> {
         let genesis_data = ancillary_input.genesis_data();
-
-        let genesis_verifying_key = genesis_data
-            .genesis_schnorr_verification_key()
-            .cloned()
-            .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
-        genesis_verifying_key.is_valid()?;
-
-        let genesis_message: MessageHash = genesis_data.genesis_message_preimage().try_into()?;
-        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+        let (genesis_verifying_key, genesis_message, genesis_bootstrap) =
+            self.check_genesis_data(genesis_data)?;
 
         let rolling_state = ancillary_input
             .prover_data()
@@ -50,41 +43,16 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
         let preimage = ProtocolMessagePreimage(preimage_bytes);
 
         let certificate_message_hash = if let Some(rolling_state) = rolling_state {
-            let (transition_type, certificate_message_hash, _) =
-                rolling_state.validate_transition(&preimage, aggregate_verification_key, msg)?;
-            rolling_state.assert_protocol_parameters_unchanged(transition_type)?;
-            certificate_message_hash
+            self.check_rolling_state(msg, aggregate_verification_key, &preimage, rolling_state)?
         } else {
-            genesis_bootstrap.genesis_signature.verify(
-                &[BaseFieldElement::from(genesis_message.as_field())],
+            self.check_genesis_bootstrap(
+                msg,
+                aggregate_verification_key,
+                &preimage,
                 &genesis_verifying_key,
-            )?;
-
-            let (certificate_message_hash, certificate_merkle_tree_commitment) =
-                create_snark_message_for_next_state(aggregate_verification_key, msg)?;
-
-            let genesis_preimage = &genesis_bootstrap.genesis_protocol_message_preimage;
-            let genesis_epoch = genesis_preimage.current_epoch();
-            let expected_epoch =
-                genesis_epoch
-                    .next_epoch()
-                    .ok_or(IvcCircuitError::InvalidEpochTransition {
-                        kind: EpochTransitionErrorKind::EpochOverflow,
-                        last_committed_epoch: genesis_epoch.as_u64(),
-                    })?;
-
-            let matches_genesis_lookahead = preimage.current_epoch().is_equal(&expected_epoch)
-                && certificate_merkle_tree_commitment
-                    == genesis_preimage.next_merkle_tree_commitment();
-            if !matches_genesis_lookahead {
-                return Err(IvcCircuitError::InvalidEpochTransition {
-                    kind: EpochTransitionErrorKind::GenesisLookaheadDoesNotMatchProtocolMessage,
-                    last_committed_epoch: genesis_epoch.as_u64(),
-                }
-                .into());
-            }
-
-            certificate_message_hash
+                &genesis_message,
+                &genesis_bootstrap,
+            )?
         };
 
         let preimage_message_hash: MessageHash = (&preimage).try_into()?;
@@ -93,6 +61,90 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
         }
 
         Ok(())
+    }
+}
+
+impl MithrilIvcOffCircuitChecker {
+    /// Checks that the genesis verification key is present and structurally valid, and parses
+    /// the genesis bootstrap input. Always run since the genesis verification key is
+    /// a public input on every proving step.
+    fn check_genesis_data(
+        &self,
+        genesis_data: &AncillaryGenesisData,
+    ) -> StmResult<(
+        SchnorrVerificationKey,
+        MessageHash,
+        IvcGenesisBootstrapInput,
+    )> {
+        let genesis_verifying_key = genesis_data
+            .genesis_schnorr_verification_key()
+            .cloned()
+            .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
+        genesis_verifying_key.is_valid()?;
+
+        let genesis_message: MessageHash = genesis_data.genesis_message_preimage().try_into()?;
+        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+
+        Ok((genesis_verifying_key, genesis_message, genesis_bootstrap))
+    }
+
+    /// Verifies the genesis signature and checks that the first real certificate matches the
+    /// genesis-announced epoch and Merkle-tree commitment lookahead. Runs only during
+    /// the genesis step.
+    fn check_genesis_bootstrap<D: MembershipDigest>(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+        preimage: &ProtocolMessagePreimage,
+        genesis_verifying_key: &SchnorrVerificationKey,
+        genesis_message: &MessageHash,
+        genesis_bootstrap: &IvcGenesisBootstrapInput,
+    ) -> StmResult<MessageHash> {
+        genesis_bootstrap.genesis_signature.verify(
+            &[BaseFieldElement::from(genesis_message.as_field())],
+            genesis_verifying_key,
+        )?;
+
+        let (certificate_message_hash, certificate_merkle_tree_commitment) =
+            create_snark_message_for_next_state(aggregate_verification_key, msg)?;
+
+        let genesis_preimage = &genesis_bootstrap.genesis_protocol_message_preimage;
+        let genesis_epoch = genesis_preimage.current_epoch();
+        let expected_epoch =
+            genesis_epoch
+                .next_epoch()
+                .ok_or(IvcCircuitError::InvalidEpochTransition {
+                    kind: EpochTransitionErrorKind::EpochOverflow,
+                    last_committed_epoch: genesis_epoch.as_u64(),
+                })?;
+
+        let matches_genesis_lookahead = preimage.current_epoch().is_equal(&expected_epoch)
+            && certificate_merkle_tree_commitment == genesis_preimage.next_merkle_tree_commitment();
+        if !matches_genesis_lookahead {
+            return Err(IvcCircuitError::InvalidEpochTransition {
+                kind: EpochTransitionErrorKind::GenesisLookaheadDoesNotMatchProtocolMessage,
+                last_committed_epoch: genesis_epoch.as_u64(),
+            }
+            .into());
+        }
+
+        Ok(certificate_message_hash)
+    }
+
+    /// Validates the incoming certificate's transition against the existing rolling state and
+    /// rejects a next-epoch transition that would promote a diverged protocol-parameters
+    /// announcement. Runs only when there is an existing rolling state.
+    fn check_rolling_state<D: MembershipDigest>(
+        &self,
+        msg: &[u8],
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+        preimage: &ProtocolMessagePreimage,
+        rolling_state: &IvcRollingState,
+    ) -> StmResult<MessageHash> {
+        let (transition_type, certificate_message_hash, _) =
+            rolling_state.validate_transition(preimage, aggregate_verification_key, msg)?;
+        rolling_state.assert_protocol_parameters_unchanged(transition_type)?;
+        Ok(certificate_message_hash)
     }
 }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -1,13 +1,8 @@
 use anyhow::anyhow;
 
 use crate::{
-    AggregateVerificationKeyForSnark, AggregationError, AncillaryProofInput, BaseFieldElement,
-    MembershipDigest, StmResult,
-    circuits::halo2_ivc::{
-        PREIMAGE_SIZE, ProtocolMessagePreimage,
-        errors::{EpochTransitionErrorKind, IvcCircuitError},
-        types::MessageHash,
-    },
+    AggregationError, AncillaryProofInput, BaseFieldElement, StmResult,
+    circuits::halo2_ivc::{PREIMAGE_SIZE, ProtocolMessagePreimage, types::MessageHash},
     proof_system::{
         IvcRollingState,
         halo2_ivc_snark::{
@@ -19,7 +14,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-struct RealIvcOffCircuitChecker;
+pub(crate) struct RealIvcOffCircuitChecker;
 
 impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
     fn check(

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
 
 use crate::{
-    AggregationError, AncillaryProofInput, BaseFieldElement, StmResult,
+    AggregateVerificationKeyForSnark, AggregationError, AncillaryProofInput, BaseFieldElement,
+    MembershipDigest, StmResult,
     circuits::halo2_ivc::{PREIMAGE_SIZE, ProtocolMessagePreimage, types::MessageHash},
     proof_system::{
         IvcRollingState,
@@ -16,22 +17,15 @@ use crate::{
 /// Production implementation of `IvcOffCircuitChecker`. Stateless: every check is a pure
 /// function of its arguments, so no setup or trusted material is needed to construct one.
 #[derive(Debug)]
-pub(crate) struct RealIvcOffCircuitChecker;
+pub(crate) struct MithrilIvcOffCircuitChecker;
 
-impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
+impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecker {
     fn off_circuit_check(
         &self,
         msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()> {
-        self.check_genesis(ancillary_input)?;
-        self.check_rolling_state(msg, aggregate_verification_key_merkle_root, ancillary_input)?;
-        self.check_protocol_message(msg, aggregate_verification_key_merkle_root, ancillary_input)?;
-        Ok(())
-    }
-
-    fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()> {
         let genesis_data = ancillary_input.genesis_data();
 
         let genesis_verifying_key = genesis_data
@@ -40,81 +34,38 @@ impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
             .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
         genesis_verifying_key.is_valid()?;
 
-        let genesis_message: MessageHash = genesis_data.genesis_message_preimage().try_into()?;
-
-        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
-        genesis_bootstrap.genesis_signature.verify(
-            &[BaseFieldElement::from(genesis_message.as_field())],
-            &genesis_verifying_key,
-        )?;
-        Ok(())
-    }
-
-    fn check_rolling_state(
-        &self,
-        msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
-        ancillary_input: &AncillaryProofInput,
-    ) -> StmResult<()> {
         let rolling_state = ancillary_input
             .prover_data()
             .and_then(|prover_data| prover_data.as_ivc_rolling_state());
+        rolling_state.map(IvcRollingState::ensure_advanceable).transpose()?;
 
-        IvcRollingState::ensure_advanceable_rolling_state(rolling_state)?;
+        let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
+        let preimage = ProtocolMessagePreimage(preimage_bytes);
 
-        let Some(rolling_state) = rolling_state else {
-            return Ok(());
+        if let Some(rolling_state) = rolling_state {
+            let (transition_type, certificate_message_hash, certificate_merkle_tree_commitment) =
+                rolling_state.validate_transition(&preimage, aggregate_verification_key, msg)?;
+            let preimage_message_hash: MessageHash = (&preimage).try_into()?;
+            if preimage_message_hash != certificate_message_hash {
+                return Err(IvcProofError::MessagePreimageMismatch.into());
+            }
+            rolling_state.assert_protocol_parameters_unchanged()?;
+        } else {
+            let genesis_message: MessageHash =
+                genesis_data.genesis_message_preimage().try_into()?;
+
+            let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+            genesis_bootstrap.genesis_signature.verify(
+                &[BaseFieldElement::from(genesis_message.as_field())],
+                &genesis_verifying_key,
+            )?;
         };
 
         let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
         let preimage = ProtocolMessagePreimage(preimage_bytes);
 
-        let (transition_type, certificate_message_hash, certificate_merkle_tree_commitment) =
-            rolling_state.validate_transition(
-                &preimage,
-                aggregate_verification_key_merkle_root,
-                msg,
-            )?;
         rolling_state.assert_protocol_parameters_unchanged()?;
 
-        Ok(())
-    }
-
-    fn check_protocol_message(
-        &self,
-        msg: &[u8],
-        aggregate_verification_key_merkle_root: &[u8],
-        ancillary_input: &AncillaryProofInput,
-    ) -> StmResult<()> {
-        let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
-        let preimage = ProtocolMessagePreimage(preimage_bytes);
-
-        let (certificate_message_hash, _) =
-            create_snark_message_for_next_state(aggregate_verification_key_merkle_root, msg)?;
-
-        let recomputed_hash: MessageHash = (&preimage).try_into()?;
-        if recomputed_hash != certificate_message_hash {
-            return Err(IvcProofError::MessagePreimageMismatch.into());
-        }
-
-        Ok(())
-    }
-}
-
-impl RealIvcOffCircuitChecker {
-    /// Asserts that the rolling state's protocol parameters have not diverged from their
-    /// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
-    /// carries the bootstrap value, so genesis is exempt; every step after that must have the two
-    /// equal, since changing protocol parameters between epochs isn't currently supported.
-    pub(crate) fn assert_protocol_parameters_unchanged(
-        rolling_state: &IvcRollingState,
-    ) -> StmResult<()> {
-        if !rolling_state.is_genesis()
-            && rolling_state.state().protocol_parameters
-                != rolling_state.state().next_protocol_parameters
-        {
-            return Err(IvcProofError::ProtocolParametersChanged.into());
-        }
         Ok(())
     }
 }
@@ -125,11 +76,14 @@ mod tests {
     use rand_core::SeedableRng;
 
     use crate::{
-        AncillaryGenesisData, AncillaryProverData,
+        AncillaryGenesisData, AncillaryProverData, MithrilMembershipDigest,
         circuits::halo2_ivc::{
             tests::common::asset_readers::{
+                load_embedded_first_certificate_in_epoch_asset,
                 load_embedded_following_certificate_in_epoch_asset,
-                load_embedded_genesis_benchmark_fixture, load_embedded_recursive_chain_state_asset,
+                load_embedded_genesis_benchmark_fixture,
+                load_embedded_next_epoch_step_output_asset,
+                load_embedded_recursive_chain_state_asset,
             },
             types::ProtocolParametersHash,
         },
@@ -170,6 +124,11 @@ mod tests {
         (signature, verification_key)
     }
 
+    // Creates an avk with a zero root
+    fn avk_with_zero_root() -> AggregateVerificationKeyForSnark<MithrilMembershipDigest> {
+        AggregateVerificationKeyForSnark::from_bytes(&[0u8; 40]).unwrap()
+    }
+
     mod check_genesis {
         use super::*;
 
@@ -178,8 +137,8 @@ mod tests {
             let genesis_data = AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, None);
             let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
-            let err = RealIvcOffCircuitChecker
-                .check_genesis(&ancillary_input)
+            let err = MithrilIvcOffCircuitChecker
+                .off_circuit_check(&[0u8; 32], &avk_with_zero_root(), &ancillary_input)
                 .expect_err("missing genesis verification key must be rejected");
 
             assert_eq!(
@@ -197,8 +156,8 @@ mod tests {
                 AncillaryGenesisData::new(vec![0u8; PREIMAGE_SIZE], None, Some(invalid_key));
             let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
-            RealIvcOffCircuitChecker
-                .check_genesis(&ancillary_input)
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(&[0u8; 32], &avk_with_zero_root(), &ancillary_input)
                 .expect_err("invalid genesis verification key must be rejected");
         }
 
@@ -213,8 +172,8 @@ mod tests {
             );
             let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
-            let err = RealIvcOffCircuitChecker
-                .check_genesis(&ancillary_input)
+            let err = MithrilIvcOffCircuitChecker
+                .off_circuit_check(&[0u8; 32], &avk_with_zero_root(), &ancillary_input)
                 .expect_err("missing genesis signature must be rejected");
 
             assert_eq!(
@@ -236,8 +195,8 @@ mod tests {
             );
             let ancillary_input = genesis_only_ancillary_input(genesis_data);
 
-            RealIvcOffCircuitChecker
-                .check_genesis(&ancillary_input)
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(&[0u8; 32], &avk_with_zero_root(), &ancillary_input)
                 .expect_err("a genesis signature over the wrong message must be rejected");
         }
 
@@ -245,17 +204,26 @@ mod tests {
         fn accepts_valid_genesis_data() {
             let genesis_fixture = load_embedded_genesis_benchmark_fixture()
                 .expect("genesis benchmark fixture should load");
+            let first_step = load_embedded_first_certificate_in_epoch_asset()
+                .expect("first-step certificate asset should load");
 
             let genesis_data = AncillaryGenesisData::new(
                 genesis_fixture.genesis_protocol_message_preimage.to_vec(),
                 Some(genesis_fixture.genesis_signature),
                 Some(genesis_fixture.genesis_verification_key),
             );
-            let ancillary_input = genesis_only_ancillary_input(genesis_data);
+            let ancillary_input =
+                AncillaryProofInput::new(None, genesis_data, first_step.message_preimage.to_vec());
 
-            RealIvcOffCircuitChecker
-                .check_genesis(&ancillary_input)
-                .expect("consistent genesis data should pass");
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
+                    &first_step.message,
+                    &first_step.aggregate_verification_key_merkle_root,
+                    &ancillary_input,
+                )
+                .expect(
+                    "consistent genesis data paired with a matching first certificate should pass",
+                );
         }
     }
 
@@ -263,19 +231,6 @@ mod tests {
         use crate::circuits::halo2_ivc::state::State;
 
         use super::*;
-
-        #[test]
-        fn accepts_when_no_rolling_state() {
-            let ancillary_input = AncillaryProofInput::new(
-                None,
-                AncillaryGenesisData::dummy(),
-                vec![0u8; PREIMAGE_SIZE],
-            );
-
-            RealIvcOffCircuitChecker
-                .check_rolling_state(&[0u8; 32], &[0u8; 32], &ancillary_input)
-                .expect("no rolling state means nothing to check here");
-        }
 
         #[test]
         fn rejects_genesis_shaped_existing_rolling_state() {
@@ -288,8 +243,8 @@ mod tests {
                 vec![0u8; PREIMAGE_SIZE],
             );
 
-            RealIvcOffCircuitChecker
-                .check_rolling_state(&[0u8; 32], &[0u8; 32], &ancillary_input)
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(&[0u8; 32], &avk_with_zero_root(), &ancillary_input)
                 .expect_err("a genesis-shaped existing rolling state must be rejected");
         }
 
@@ -305,13 +260,16 @@ mod tests {
                 step.message_preimage.to_vec(),
             );
 
-            RealIvcOffCircuitChecker
-                .check_rolling_state(
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
                     &step.message,
                     &step.aggregate_verification_key_merkle_root,
                     &ancillary_input,
                 )
-                .expect("consistent same-epoch step should pass");
+                .expect(
+                    "consistent same-epoch step should pass every check, including the \
+                     message-hash match",
+                );
         }
 
         #[test]
@@ -345,8 +303,8 @@ mod tests {
                 step.message_preimage.to_vec(),
             );
 
-            RealIvcOffCircuitChecker
-                .check_rolling_state(
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
                     &step.message,
                     &step.aggregate_verification_key_merkle_root,
                     &ancillary_input,
@@ -362,11 +320,16 @@ mod tests {
         fn rejects_wrong_size_preimage() {
             let step = load_embedded_following_certificate_in_epoch_asset()
                 .expect("same-epoch step output asset should load");
-            let ancillary_input =
-                AncillaryProofInput::new(None, AncillaryGenesisData::dummy(), vec![0u8; 3]);
+            let ancillary_input = AncillaryProofInput::new(
+                Some(AncillaryProverData::IvcSnark(
+                    rolling_state_from_chain_state(),
+                )),
+                AncillaryGenesisData::dummy(),
+                vec![0u8; 3],
+            );
 
-            RealIvcOffCircuitChecker
-                .check_protocol_message(
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
                     &step.message,
                     &step.aggregate_verification_key_merkle_root,
                     &ancillary_input,
@@ -378,38 +341,28 @@ mod tests {
         fn rejects_mismatched_message_hash() {
             let step = load_embedded_following_certificate_in_epoch_asset()
                 .expect("same-epoch step output asset should load");
+
+            // Flip a byte outside the three decoded slots (next merkle-tree commitment, next
+            // protocol parameters, current epoch) so assert_correct_parameters and
+            // assert_protocol_parameters_unchanged still pass, isolating the message-hash check.
+            let mut corrupted_preimage = step.message_preimage;
+            corrupted_preimage[0] ^= 0xFF;
+
             let ancillary_input = AncillaryProofInput::new(
-                None,
+                Some(AncillaryProverData::IvcSnark(
+                    rolling_state_from_chain_state(),
+                )),
                 AncillaryGenesisData::dummy(),
-                vec![0u8; PREIMAGE_SIZE],
+                corrupted_preimage.to_vec(),
             );
 
-            RealIvcOffCircuitChecker
-                .check_protocol_message(
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
                     &step.message,
                     &step.aggregate_verification_key_merkle_root,
                     &ancillary_input,
                 )
                 .expect_err("mismatched preimage must be rejected");
-        }
-
-        #[test]
-        fn accepts_matching_message_hash() {
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
-            let ancillary_input = AncillaryProofInput::new(
-                None,
-                AncillaryGenesisData::dummy(),
-                step.message_preimage.to_vec(),
-            );
-
-            RealIvcOffCircuitChecker
-                .check_protocol_message(
-                    &step.message,
-                    &step.aggregate_verification_key_merkle_root,
-                    &ancillary_input,
-                )
-                .expect("consistent message/preimage should pass");
         }
     }
 
@@ -432,12 +385,40 @@ mod tests {
             step.message_preimage.to_vec(),
         );
 
-        RealIvcOffCircuitChecker
+        MithrilIvcOffCircuitChecker
             .off_circuit_check(
                 &step.message,
                 &step.aggregate_verification_key_merkle_root,
                 &ancillary_input,
             )
             .expect("a fully consistent request should pass every check");
+    }
+
+    #[test]
+    fn check_accepts_a_fully_consistent_next_epoch_request() {
+        let step = load_embedded_next_epoch_step_output_asset()
+            .expect("next-epoch step output asset should load");
+        let genesis_fixture = load_embedded_genesis_benchmark_fixture()
+            .expect("genesis benchmark fixture should load");
+        let genesis_data = AncillaryGenesisData::new(
+            genesis_fixture.genesis_protocol_message_preimage.to_vec(),
+            Some(genesis_fixture.genesis_signature),
+            Some(genesis_fixture.genesis_verification_key),
+        );
+        let ancillary_input = AncillaryProofInput::new(
+            Some(AncillaryProverData::IvcSnark(
+                rolling_state_from_chain_state(),
+            )),
+            genesis_data,
+            step.message_preimage.to_vec(),
+        );
+
+        MithrilIvcOffCircuitChecker
+            .off_circuit_check(
+                &step.message,
+                &step.aggregate_verification_key_merkle_root,
+                &ancillary_input,
+            )
+            .expect("a fully consistent next-epoch request should pass every check");
     }
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -1,13 +1,19 @@
 use anyhow::anyhow;
 
 use crate::{
-    AggregationError, AncillaryProofInput, BaseFieldElement, StmResult,
-    circuits::halo2_ivc::{PREIMAGE_SIZE, ProtocolMessagePreimage, types::MessageHash},
+    AggregateVerificationKeyForSnark, AggregationError, AncillaryProofInput, BaseFieldElement,
+    MembershipDigest, StmResult,
+    circuits::halo2_ivc::{
+        PREIMAGE_SIZE, ProtocolMessagePreimage,
+        errors::{EpochTransitionErrorKind, IvcCircuitError},
+        types::MessageHash,
+    },
     proof_system::{
         IvcRollingState,
         halo2_ivc_snark::{
             IvcTransitionType, errors::IvcProofError, interface::IvcOffCircuitChecker,
             proof::IvcGenesisBootstrapInput,
+            prover_input_helpers::create_snark_message_for_next_state,
         },
     },
 };
@@ -22,7 +28,10 @@ impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
         aggregate_verification_key_merkle_root: &[u8],
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()> {
-        todo!()
+        self.check_genesis(ancillary_input)?;
+        self.check_rolling_state(msg, aggregate_verification_key_merkle_root, ancillary_input)?;
+        self.check_protocol_message(msg, aggregate_verification_key_merkle_root, ancillary_input)?;
+        Ok(())
     }
 
     fn check_genesis(&self, ancillary_input: &AncillaryProofInput) -> StmResult<()> {
@@ -54,7 +63,7 @@ impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
             .prover_data()
             .and_then(|prover_data| prover_data.as_ivc_rolling_state());
 
-        ensure_advanceable_rolling_state(rolling_state)?;
+        IvcRollingState::ensure_advanceable_rolling_state(rolling_state)?;
 
         let Some(rolling_state) = rolling_state else {
             return Ok(());
@@ -80,22 +89,33 @@ impl IvcOffCircuitChecker for RealIvcOffCircuitChecker {
         aggregate_verification_key_merkle_root: &[u8],
         ancillary_input: &AncillaryProofInput,
     ) -> StmResult<()> {
-        todo!()
+        let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
+        let preimage = ProtocolMessagePreimage(preimage_bytes);
+
+        let (certificate_message_hash, _) =
+            create_snark_message_for_next_state(aggregate_verification_key_merkle_root, msg)?;
+
+        let recomputed_hash: MessageHash = (&preimage).try_into()?;
+        if recomputed_hash != certificate_message_hash {
+            return Err(IvcProofError::MessagePreimageMismatch.into());
+        }
+
+        Ok(())
     }
 }
 
-/// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
-///
-/// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
-/// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
-/// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
-/// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
-/// both-`None` misuses are now unrepresentable.
-pub(crate) fn ensure_advanceable_rolling_state(
-    rolling_state: Option<&IvcRollingState>,
+/// Asserts that the rolling state's protocol parameters have not diverged from their
+/// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
+/// carries the bootstrap value, so genesis is exempt; every step after that must have the two
+/// equal, since changing protocol parameters between epochs isn't currently supported.
+pub(crate) fn assert_protocol_parameters_unchanged(
+    rolling_state: &IvcRollingState,
 ) -> StmResult<()> {
-    if rolling_state.is_some_and(|rs| rs.is_genesis()) {
-        return Err(IvcProofError::InvalidProvingContext.into());
+    if !rolling_state.is_genesis()
+        && rolling_state.state().protocol_parameters
+            != rolling_state.state().next_protocol_parameters
+    {
+        return Err(IvcProofError::ProtocolParametersChanged.into());
     }
     Ok(())
 }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/off_circuit_checker.rs
@@ -3,11 +3,15 @@ use anyhow::anyhow;
 use crate::{
     AggregateVerificationKeyForSnark, AggregationError, AncillaryProofInput, BaseFieldElement,
     MembershipDigest, StmResult,
-    circuits::halo2_ivc::{PREIMAGE_SIZE, ProtocolMessagePreimage, types::MessageHash},
+    circuits::halo2_ivc::{
+        PREIMAGE_SIZE, ProtocolMessagePreimage,
+        errors::{EpochTransitionErrorKind, IvcCircuitError},
+        types::MessageHash,
+    },
     proof_system::{
         IvcRollingState,
         halo2_ivc_snark::{
-            IvcTransitionType, errors::IvcProofError, interface::IvcOffCircuitChecker,
+            errors::IvcProofError, interface::IvcOffCircuitChecker,
             proof::IvcGenesisBootstrapInput,
             prover_input_helpers::create_snark_message_for_next_state,
         },
@@ -34,6 +38,9 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
             .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
         genesis_verifying_key.is_valid()?;
 
+        let genesis_message: MessageHash = genesis_data.genesis_message_preimage().try_into()?;
+        let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
+
         let rolling_state = ancillary_input
             .prover_data()
             .and_then(|prover_data| prover_data.as_ivc_rolling_state());
@@ -42,29 +49,49 @@ impl<D: MembershipDigest> IvcOffCircuitChecker<D> for MithrilIvcOffCircuitChecke
         let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
         let preimage = ProtocolMessagePreimage(preimage_bytes);
 
-        if let Some(rolling_state) = rolling_state {
-            let (transition_type, certificate_message_hash, certificate_merkle_tree_commitment) =
+        let certificate_message_hash = if let Some(rolling_state) = rolling_state {
+            let (transition_type, certificate_message_hash, _) =
                 rolling_state.validate_transition(&preimage, aggregate_verification_key, msg)?;
-            let preimage_message_hash: MessageHash = (&preimage).try_into()?;
-            if preimage_message_hash != certificate_message_hash {
-                return Err(IvcProofError::MessagePreimageMismatch.into());
-            }
-            rolling_state.assert_protocol_parameters_unchanged()?;
+            rolling_state.assert_protocol_parameters_unchanged(transition_type)?;
+            certificate_message_hash
         } else {
-            let genesis_message: MessageHash =
-                genesis_data.genesis_message_preimage().try_into()?;
-
-            let genesis_bootstrap: IvcGenesisBootstrapInput = genesis_data.try_into()?;
             genesis_bootstrap.genesis_signature.verify(
                 &[BaseFieldElement::from(genesis_message.as_field())],
                 &genesis_verifying_key,
             )?;
+
+            let (certificate_message_hash, certificate_merkle_tree_commitment) =
+                create_snark_message_for_next_state(aggregate_verification_key, msg)?;
+
+            let genesis_preimage = &genesis_bootstrap.genesis_protocol_message_preimage;
+            let genesis_epoch = genesis_preimage.current_epoch();
+            let expected_epoch =
+                genesis_epoch
+                    .next_epoch()
+                    .ok_or(IvcCircuitError::InvalidEpochTransition {
+                        kind: EpochTransitionErrorKind::EpochOverflow,
+                        last_committed_epoch: genesis_epoch.as_u64(),
+                    })?;
+
+            let matches_genesis_lookahead = preimage.current_epoch().is_equal(&expected_epoch)
+                && certificate_merkle_tree_commitment
+                    == genesis_preimage.next_merkle_tree_commitment();
+            if !matches_genesis_lookahead {
+                return Err(IvcCircuitError::InvalidEpochTransition {
+                    kind:
+                        EpochTransitionErrorKind::RollingStateParametersDoesNotMatchProtocolMessage,
+                    last_committed_epoch: genesis_epoch.as_u64(),
+                }
+                .into());
+            }
+
+            certificate_message_hash
         };
 
-        let preimage_bytes: [u8; PREIMAGE_SIZE] = ancillary_input.message_preimage().try_into()?;
-        let preimage = ProtocolMessagePreimage(preimage_bytes);
-
-        rolling_state.assert_protocol_parameters_unchanged()?;
+        let preimage_message_hash: MessageHash = (&preimage).try_into()?;
+        if preimage_message_hash != certificate_message_hash {
+            return Err(IvcProofError::MessagePreimageMismatch.into());
+        }
 
         Ok(())
     }
@@ -127,6 +154,15 @@ mod tests {
     // Creates an avk with a zero root
     fn avk_with_zero_root() -> AggregateVerificationKeyForSnark<MithrilMembershipDigest> {
         AggregateVerificationKeyForSnark::from_bytes(&[0u8; 40]).unwrap()
+    }
+
+    // Wraps a raw merkle-tree-commitment root (as stored in the fixture assets) into an
+    // AggregateVerificationKeyForSnark. Total stake is irrelevant here: off_circuit_check only
+    // ever reads `.get_merkle_tree_commitment().root` from it, never the stake.
+    fn avk_with_root(root: [u8; 32]) -> AggregateVerificationKeyForSnark<MithrilMembershipDigest> {
+        let mut bytes = [0u8; 40];
+        bytes[..32].copy_from_slice(&root);
+        AggregateVerificationKeyForSnark::from_bytes(&bytes).unwrap()
     }
 
     mod check_genesis {
@@ -218,7 +254,7 @@ mod tests {
             MithrilIvcOffCircuitChecker
                 .off_circuit_check(
                     &first_step.message,
-                    &first_step.aggregate_verification_key_merkle_root,
+                    &avk_with_root(first_step.aggregate_verification_key_merkle_root),
                     &ancillary_input,
                 )
                 .expect(
@@ -263,7 +299,7 @@ mod tests {
             MithrilIvcOffCircuitChecker
                 .off_circuit_check(
                     &step.message,
-                    &step.aggregate_verification_key_merkle_root,
+                    &avk_with_root(step.aggregate_verification_key_merkle_root),
                     &ancillary_input,
                 )
                 .expect(
@@ -272,16 +308,12 @@ mod tests {
                 );
         }
 
-        #[test]
-        fn rejects_when_protocol_parameters_diverged() {
-            let step = load_embedded_following_certificate_in_epoch_asset()
-                .expect("same-epoch step output asset should load");
+        // Builds a rolling state whose `protocol_parameters` diverges from `next_protocol_parameters`
+        // (as if an earlier certificate had announced a parameter change for the following epoch),
+        // otherwise carrying the same fields as the embedded recursive chain state asset.
+        fn diverged_rolling_state() -> IvcRollingState {
             let chain_state = load_embedded_recursive_chain_state_asset()
                 .expect("recursive chain state asset should load");
-
-            // Only current `protocol_parameters` diverges from `next_protocol_parameters`;
-            // assert_correct_parameters never checks the current value, so this reaches the
-            // protocol-parameters-unchanged check specifically.
             let diverged_state = State::new(
                 chain_state.state.step_counter,
                 chain_state.state.message,
@@ -291,14 +323,23 @@ mod tests {
                 chain_state.state.next_protocol_parameters,
                 chain_state.state.current_epoch,
             );
-            let rolling_state = IvcRollingState::new(
+            IvcRollingState::new(
                 diverged_state,
                 chain_state.ivc_proof,
                 chain_state.accumulator,
                 chain_state.genesis_signature,
-            );
+            )
+        }
+
+        #[test]
+        fn accepts_when_protocol_parameters_diverged_within_same_epoch() {
+            // A same-epoch step never consumes `next_protocol_parameters`, so a chain that
+            // already carries a divergence can still process the rest of the epoch where it
+            // appeared.
+            let step = load_embedded_following_certificate_in_epoch_asset()
+                .expect("same-epoch step output asset should load");
             let ancillary_input = AncillaryProofInput::new(
-                Some(AncillaryProverData::IvcSnark(rolling_state)),
+                Some(AncillaryProverData::IvcSnark(diverged_rolling_state())),
                 AncillaryGenesisData::dummy(),
                 step.message_preimage.to_vec(),
             );
@@ -306,10 +347,33 @@ mod tests {
             MithrilIvcOffCircuitChecker
                 .off_circuit_check(
                     &step.message,
-                    &step.aggregate_verification_key_merkle_root,
+                    &avk_with_root(step.aggregate_verification_key_merkle_root),
                     &ancillary_input,
                 )
-                .expect_err("diverged protocol parameters must be rejected");
+                .expect("a same-epoch step must still succeed despite the diverged lookahead");
+        }
+
+        #[test]
+        fn rejects_when_protocol_parameters_diverged_at_next_epoch() {
+            // A next-epoch transition promotes `next_protocol_parameters` into
+            // `protocol_parameters`, so this is where a diverged lookahead must be rejected.
+            let step = load_embedded_next_epoch_step_output_asset()
+                .expect("next-epoch step output asset should load");
+            let ancillary_input = AncillaryProofInput::new(
+                Some(AncillaryProverData::IvcSnark(diverged_rolling_state())),
+                AncillaryGenesisData::dummy(),
+                step.message_preimage.to_vec(),
+            );
+
+            MithrilIvcOffCircuitChecker
+                .off_circuit_check(
+                    &step.message,
+                    &avk_with_root(step.aggregate_verification_key_merkle_root),
+                    &ancillary_input,
+                )
+                .expect_err(
+                    "a next-epoch transition promoting diverged parameters must be rejected",
+                );
         }
     }
 
@@ -331,7 +395,7 @@ mod tests {
             MithrilIvcOffCircuitChecker
                 .off_circuit_check(
                     &step.message,
-                    &step.aggregate_verification_key_merkle_root,
+                    &avk_with_root(step.aggregate_verification_key_merkle_root),
                     &ancillary_input,
                 )
                 .expect_err("wrong-size preimage must be rejected");
@@ -359,7 +423,7 @@ mod tests {
             MithrilIvcOffCircuitChecker
                 .off_circuit_check(
                     &step.message,
-                    &step.aggregate_verification_key_merkle_root,
+                    &avk_with_root(step.aggregate_verification_key_merkle_root),
                     &ancillary_input,
                 )
                 .expect_err("mismatched preimage must be rejected");
@@ -388,7 +452,7 @@ mod tests {
         MithrilIvcOffCircuitChecker
             .off_circuit_check(
                 &step.message,
-                &step.aggregate_verification_key_merkle_root,
+                &avk_with_root(step.aggregate_verification_key_merkle_root),
                 &ancillary_input,
             )
             .expect("a fully consistent request should pass every check");
@@ -416,7 +480,7 @@ mod tests {
         MithrilIvcOffCircuitChecker
             .off_circuit_check(
                 &step.message,
-                &step.aggregate_verification_key_merkle_root,
+                &avk_with_root(step.aggregate_verification_key_merkle_root),
                 &ancillary_input,
             )
             .expect("a fully consistent next-epoch request should pass every check");

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -609,31 +609,33 @@ mod tests {
     use crate::{
         AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
         MithrilMembershipDigest, Parameters, SnarkProof,
-        circuits::halo2::{
-            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-            keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase,
-        },
-        circuits::halo2_ivc::{
-            PREIMAGE_SIZE, RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-            keys::RecursiveCircuitVerifyingKey,
-            state::Global,
-            tests::common::{
-                asset_readers::{
-                    load_embedded_following_certificate_in_epoch_asset,
-                    load_embedded_next_epoch_step_output_asset,
-                    load_embedded_recursive_chain_state_asset,
-                    load_embedded_verification_context_asset,
-                },
-                generators::{build_asset_generation_setup_from_cache, build_recursive_global},
+        circuits::{
+            halo2::{
+                NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+                keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase,
             },
-            types::{EpochNumber, IvcProofBytes, MessageHash, StepCounter},
+            halo2_ivc::{
+                PREIMAGE_SIZE, RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+                keys::RecursiveCircuitVerifyingKey,
+                state::Global,
+                tests::common::{
+                    asset_readers::{
+                        load_embedded_following_certificate_in_epoch_asset,
+                        load_embedded_next_epoch_step_output_asset,
+                        load_embedded_recursive_chain_state_asset,
+                        load_embedded_verification_context_asset,
+                    },
+                    generators::{build_asset_generation_setup_from_cache, build_recursive_global},
+                },
+                types::{EpochNumber, IvcProofBytes, MessageHash, StepCounter},
+            },
         },
         codec::TryFromBytes,
         proof_system::{
-            AggregateVerificationKeyForSnark, MERKLE_TREE_DEPTH_FOR_SNARK,
+            AggregateVerificationKeyForSnark, IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK,
             halo2_ivc_snark::{
                 build_standard_rolling_state, errors::IvcProofError,
-                rolling_state::IvcRollingState, verifier_setup::IvcVerifierSetup,
+                verifier_setup::IvcVerifierSetup,
             },
         },
         signature_scheme::{BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey},

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -631,7 +631,7 @@ mod tests {
         },
         codec::TryFromBytes,
         proof_system::{
-            AggregateVerificationKeyForSnark, IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK,
+            AggregateVerificationKeyForSnark, MERKLE_TREE_DEPTH_FOR_SNARK,
             halo2_ivc_snark::{
                 build_standard_rolling_state, errors::IvcProofError,
                 verifier_setup::IvcVerifierSetup,
@@ -1051,50 +1051,6 @@ mod tests {
                 "combined check must hold for a valid proof regardless of the combiner r={r:?}"
             );
         }
-    }
-
-    // The context guard is the first thing `IvcProver::prove` runs. It is tested directly here
-    // rather than through `prove` so the test stays fast: reaching `prove` would require building
-    // an `IvcProverSetup` (full keygen). With `genesis_bootstrap` now always supplied, a genesis
-    // `rolling_state` is the only remaining invalid context; both-`Some`/both-`None` are
-    // unrepresentable.
-    #[test]
-    fn ensure_advanceable_rolling_state_rejects_only_genesis_state() {
-        // A genesis signature is needed to build any rolling state; its value is irrelevant
-        // because the guard only inspects the step counter.
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let signing_key = SchnorrSigningKey::generate(&mut rng);
-        let genesis_signature = signing_key
-            .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
-            .expect("genesis signature should be produced");
-
-        // `None` bootstraps from genesis internally: accepted.
-        IvcRollingState::ensure_advanceable_rolling_state(None)
-            .expect("None must be accepted (genesis bootstrap)");
-
-        // A genesis rolling state (`step_counter == 0`) must be rejected.
-        let genesis_state = IvcRollingState::genesis(genesis_signature, &[]);
-        assert!(genesis_state.is_genesis());
-        let err = IvcRollingState::ensure_advanceable_rolling_state(Some(&genesis_state))
-            .expect_err("genesis rolling state must be rejected");
-        assert_eq!(
-            err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::InvalidProvingContext),
-            "genesis rolling state must fail with InvalidProvingContext, got: {err}"
-        );
-
-        // A non-genesis rolling state (a previous step's output) is accepted.
-        let chain_state = load_embedded_recursive_chain_state_asset()
-            .expect("recursive chain state asset should load");
-        let advanced_state = IvcRollingState::new(
-            chain_state.state,
-            chain_state.ivc_proof,
-            chain_state.accumulator,
-            chain_state.genesis_signature,
-        );
-        assert!(!advanced_state.is_genesis());
-        IvcRollingState::ensure_advanceable_rolling_state(Some(&advanced_state))
-            .expect("a non-genesis rolling state must be accepted");
     }
 
     /// Cheapest possible valid inputs for `IvcChainStepBundle::try_new`: a proof/AVK that never get

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -410,8 +410,7 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
         genesis_bootstrap: &IvcGenesisBootstrapInput,
         rolling_state: Option<&IvcRollingState>,
     ) -> StmResult<(IvcProof<Blake2b256>, Option<IvcRollingState>)> {
-        IvcRollingState::ensure_advanceable_rolling_state(rolling_state)?;
-
+        rolling_state.map(IvcRollingState::ensure_advanceable).transpose()?;
         // `rolling_state = None` is the first certificate: bootstrap from genesis internally,
         // then continue with the seeded state. Otherwise advance from the supplied state.
         let effective_rolling_state: &IvcRollingState = match rolling_state {

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -46,7 +46,6 @@ use crate::{
     proof_system::halo2_ivc_snark::{
         errors::IvcProofError,
         interface::IvcChainProver,
-        off_circuit_checker::ensure_advanceable_rolling_state,
         prover_input::IvcProverInput,
         prover_setup::IvcProverSetup,
         rolling_state::{IvcRollingState, IvcTransitionType, midnight_accumulator_serde},
@@ -411,7 +410,7 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
         genesis_bootstrap: &IvcGenesisBootstrapInput,
         rolling_state: Option<&IvcRollingState>,
     ) -> StmResult<(IvcProof<Blake2b256>, Option<IvcRollingState>)> {
-        ensure_advanceable_rolling_state(rolling_state)?;
+        IvcRollingState::ensure_advanceable_rolling_state(rolling_state)?;
 
         // `rolling_state = None` is the first certificate: bootstrap from genesis internally,
         // then continue with the seeded state. Otherwise advance from the supplied state.
@@ -640,7 +639,7 @@ mod tests {
         signature_scheme::{BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey},
     };
 
-    use super::{IvcChainStepBundle, IvcProof, ensure_advanceable_rolling_state};
+    use super::{IvcChainStepBundle, IvcProof};
 
     const STEP_OUTPUT_MSG: [u8; 32] = [
         22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
@@ -1069,12 +1068,13 @@ mod tests {
             .expect("genesis signature should be produced");
 
         // `None` bootstraps from genesis internally: accepted.
-        ensure_advanceable_rolling_state(None).expect("None must be accepted (genesis bootstrap)");
+        IvcRollingState::ensure_advanceable_rolling_state(None)
+            .expect("None must be accepted (genesis bootstrap)");
 
         // A genesis rolling state (`step_counter == 0`) must be rejected.
         let genesis_state = IvcRollingState::genesis(genesis_signature, &[]);
         assert!(genesis_state.is_genesis());
-        let err = ensure_advanceable_rolling_state(Some(&genesis_state))
+        let err = IvcRollingState::ensure_advanceable_rolling_state(Some(&genesis_state))
             .expect_err("genesis rolling state must be rejected");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -1092,7 +1092,7 @@ mod tests {
             chain_state.genesis_signature,
         );
         assert!(!advanced_state.is_genesis());
-        ensure_advanceable_rolling_state(Some(&advanced_state))
+        IvcRollingState::ensure_advanceable_rolling_state(Some(&advanced_state))
             .expect("a non-genesis rolling state must be accepted");
     }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -46,6 +46,7 @@ use crate::{
     proof_system::halo2_ivc_snark::{
         errors::IvcProofError,
         interface::IvcChainProver,
+        off_circuit_checker::ensure_advanceable_rolling_state,
         prover_input::IvcProverInput,
         prover_setup::IvcProverSetup,
         rolling_state::{IvcRollingState, IvcTransitionType, midnight_accumulator_serde},
@@ -301,20 +302,6 @@ where
         .map_err(|e| IvcProofError::ProofGenerationFailed(e.to_string()))?;
         Ok(transcript.finalize())
     }
-}
-
-/// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
-///
-/// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
-/// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
-/// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
-/// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
-/// both-`None` misuses are now unrepresentable.
-fn ensure_advanceable_rolling_state(rolling_state: Option<&IvcRollingState>) -> StmResult<()> {
-    if rolling_state.is_some_and(|rs| rs.is_genesis()) {
-        return Err(IvcProofError::InvalidProvingContext.into());
-    }
-    Ok(())
 }
 
 /// Everything the IVC prover needs to add one certificate to the chain, assembled by the clerk.

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -34,6 +34,7 @@ use crate::{
         halo2::{keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase},
         halo2_ivc::{
             PREIMAGE_SIZE,
+            accumulator::check_accumulator_fixed_bases_present,
             circuit::IvcCircuitData,
             keys::{RecursiveCircuitProvingKey, RecursiveCircuitVerifyingKey},
             state::{Global, State},
@@ -185,6 +186,10 @@ where
             .assert_empty()
             .map_err(|_| IvcProofError::TranscriptNotFullyConsumed)?;
 
+        check_accumulator_fixed_bases_present(
+            &self.accumulator,
+            verifier_setup.combined_fixed_bases(),
+        )?;
         let accumulator_lhs = self.accumulator.lhs().eval(verifier_setup.combined_fixed_bases());
         let accumulator_rhs = self.accumulator.rhs().eval(verifier_setup.combined_fixed_bases());
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
@@ -5,6 +5,8 @@ use midnight_proofs::poly::kzg::msm::DualMSM;
 use crate::{
     AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
     circuits::halo2_ivc::{
+        accumulator::check_accumulator_fixed_bases_present,
+        errors::{EpochTransitionErrorKind, IvcCircuitError},
         state::{Global, State},
         types::{MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage},
     },
@@ -106,9 +108,15 @@ pub(crate) fn build_next_accumulator(
         previous_ivc_proof_collapsed_accumulator,
     ]);
     next_accumulator.collapse();
+    let combined_fixed_bases = verification_context.combined_fixed_bases();
+    check_accumulator_fixed_bases_present(&next_accumulator, &combined_fixed_bases)?;
+    // The certificate and previous-IVC-proof accumulators are already individually
+    // pairing-checked above; by bilinearity their fold is too. This only fires against
+    // `rolling_state.accumulator()`, the one input never independently re-checked here —
+    // defense-in-depth for a rolling state loaded from persisted/untrusted storage.
     if !next_accumulator.check(
         verification_context.verifier_params(),
-        &verification_context.combined_fixed_bases(),
+        &combined_fixed_bases,
     ) {
         return Err(IvcProofError::InvalidNextAccumulator.into());
     }

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
@@ -6,7 +6,6 @@ use crate::{
     AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
     circuits::halo2_ivc::{
         accumulator::check_accumulator_fixed_bases_present,
-        errors::{EpochTransitionErrorKind, IvcCircuitError},
         state::{Global, State},
         types::{MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage},
     },

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_input_helpers.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     proof_system::{
         halo2_ivc_snark::{
-            prover_setup::IvcProverInputVerificationContext,
-            rolling_state::{IvcRollingState, IvcTransitionType},
+            IvcTransitionType, errors::IvcProofError,
+            prover_setup::IvcProverInputVerificationContext, rolling_state::IvcRollingState,
         },
         halo2_snark::build_snark_message,
     },
@@ -106,6 +106,12 @@ pub(crate) fn build_next_accumulator(
         previous_ivc_proof_collapsed_accumulator,
     ]);
     next_accumulator.collapse();
+    if !next_accumulator.check(
+        verification_context.verifier_params(),
+        &verification_context.combined_fixed_bases(),
+    ) {
+        return Err(IvcProofError::InvalidNextAccumulator.into());
+    }
     Ok(next_accumulator)
 }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
@@ -261,6 +261,13 @@ impl IvcProverInputVerificationContext {
         &self.verifier_params
     }
 
+    /// Returns the union of the certificate and IVC fixed-base maps, keyed by name.
+    pub(crate) fn combined_fixed_bases(&self) -> BTreeMap<String, G1Projective> {
+        let mut combined = self.certificate_fixed_bases.clone();
+        combined.extend(self.ivc_fixed_bases.clone());
+        combined
+    }
+
     /// Wrap the certificate proof's prepared `DualMSM` into a collapsed accumulator on
     /// the certificate circuit's fixed bases.
     pub(crate) fn certificate_collapsed_accumulator(

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
@@ -263,9 +263,11 @@ impl IvcProverInputVerificationContext {
 
     /// Returns the union of the certificate and IVC fixed-base maps, keyed by name.
     pub(crate) fn combined_fixed_bases(&self) -> BTreeMap<String, G1Projective> {
-        let mut combined = self.certificate_fixed_bases.clone();
-        combined.extend(self.ivc_fixed_bases.clone());
-        combined
+        self.certificate_fixed_bases
+            .iter()
+            .chain(self.ivc_fixed_bases.iter())
+            .map(|(name, base)| (name.clone(), *base))
+            .collect()
     }
 
     /// Wrap the certificate proof's prepared `DualMSM` into a collapsed accumulator on

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
@@ -214,17 +214,22 @@ impl IvcRollingState {
         ))
     }
 
-    /// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
-    ///
-    /// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
-    /// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
-    /// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
-    /// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
-    /// both-`None` misuses are now unrepresentable.
-    pub(crate) fn ensure_advanceable_rolling_state(
-        rolling_state: Option<&IvcRollingState>,
-    ) -> StmResult<()> {
-        if rolling_state.is_some_and(|rs| rs.is_genesis()) {
+    /// Asserts that the rolling state's protocol parameters have not diverged from their
+    /// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
+    /// carries the bootstrap value, so genesis is exempt; every step after that must have the two
+    /// equal, since changing protocol parameters between epochs isn't currently supported.
+    pub(crate) fn assert_protocol_parameters_unchanged(&self) -> StmResult<()> {
+        if !self.is_genesis()
+            && self.state().protocol_parameters != self.state().next_protocol_parameters
+        {
+            return Err(IvcProofError::ProtocolParametersChanged.into());
+        }
+        Ok(())
+    }
+
+    /// Rejects `self` if that carries a genesis state (`step_counter == 0`).
+    pub(crate) fn ensure_advanceable(&self) -> StmResult<()> {
+        if self.is_genesis() {
             return Err(IvcProofError::InvalidProvingContext.into());
         }
         Ok(())
@@ -343,13 +348,15 @@ mod tests {
             .expect("genesis signature should be produced");
 
         // `None` bootstraps from genesis internally: accepted.
-        IvcRollingState::ensure_advanceable_rolling_state(None)
+        None.map(IvcRollingState::ensure_advanceable)
+            .transpose()
             .expect("None must be accepted (genesis bootstrap)");
 
         // A genesis rolling state (`step_counter == 0`) must be rejected.
         let genesis_state = IvcRollingState::genesis(genesis_signature, &[]);
         assert!(genesis_state.is_genesis());
-        let err = IvcRollingState::ensure_advanceable_rolling_state(Some(&genesis_state))
+        let err = genesis_state
+            .ensure_advanceable()
             .expect_err("genesis rolling state must be rejected");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -367,7 +374,8 @@ mod tests {
             chain_state.genesis_signature,
         );
         assert!(!advanced_state.is_genesis());
-        IvcRollingState::ensure_advanceable_rolling_state(Some(&advanced_state))
+        advanced_state
+            .ensure_advanceable()
             .expect("a non-genesis rolling state must be accepted");
     }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
@@ -218,8 +218,8 @@ impl IvcRollingState {
     /// value into `protocol_parameters`.
     ///
     /// A `SameEpoch` transition never consumes `next_protocol_parameters` (see `build_next_state`),
-    /// so a chain that already carries a divergence — from an earlier certificate that announced a
-    /// parameter change — can still process every remaining `SameEpoch` certificate in the epoch
+    /// so a chain that already carries a divergence, from an earlier certificate that announced a
+    /// parameter change, can still process every remaining `SameEpoch` certificate in the epoch
     /// where the divergence appeared; only the `NextEpoch` transition that would actually promote
     /// the diverged value into the new epoch is rejected.
     pub(crate) fn assert_protocol_parameters_unchanged(

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
@@ -18,7 +18,9 @@ use crate::{
             types::{IvcProofBytes, MerkleTreeCommitment, MessageHash, StepCounter},
         },
     },
-    proof_system::halo2_ivc_snark::prover_input_helpers::create_snark_message_for_next_state,
+    proof_system::halo2_ivc_snark::{
+        errors::IvcProofError, prover_input_helpers::create_snark_message_for_next_state,
+    },
     signature_scheme::{BaseFieldElement, StandardSchnorrSignature},
 };
 
@@ -210,6 +212,22 @@ impl IvcRollingState {
             certificate_message_hash,
             certificate_merkle_tree_commitment,
         ))
+    }
+
+    /// Rejects a `rolling_state` that carries a genesis state (`step_counter == 0`).
+    ///
+    /// The genesis step is only ever produced internally by the bootstrap path; callers reach it by
+    /// passing `rolling_state = None`. A genesis state supplied as a previous step would instead run
+    /// a normal step that silently ignores the certificate. Since `genesis_bootstrap` is always
+    /// supplied, this is the only remaining invalid context: the previously-possible both-`Some` and
+    /// both-`None` misuses are now unrepresentable.
+    pub(crate) fn ensure_advanceable_rolling_state(
+        rolling_state: Option<&IvcRollingState>,
+    ) -> StmResult<()> {
+        if rolling_state.is_some_and(|rs| rs.is_genesis()) {
+            return Err(IvcProofError::InvalidProvingContext.into());
+        }
+        Ok(())
     }
 }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
@@ -214,12 +214,20 @@ impl IvcRollingState {
         ))
     }
 
-    /// Asserts that the rolling state's protocol parameters have not diverged from their
-    /// lookahead value. At genesis `protocol_parameters` is zeroed while `next_protocol_parameters`
-    /// carries the bootstrap value, so genesis is exempt; every step after that must have the two
-    /// equal, since changing protocol parameters between epochs isn't currently supported.
-    pub(crate) fn assert_protocol_parameters_unchanged(&self) -> StmResult<()> {
+    /// Asserts that a `NextEpoch` transition does not promote a diverged `next_protocol_parameters`
+    /// value into `protocol_parameters`.
+    ///
+    /// A `SameEpoch` transition never consumes `next_protocol_parameters` (see `build_next_state`),
+    /// so a chain that already carries a divergence — from an earlier certificate that announced a
+    /// parameter change — can still process every remaining `SameEpoch` certificate in the epoch
+    /// where the divergence appeared; only the `NextEpoch` transition that would actually promote
+    /// the diverged value into the new epoch is rejected.
+    pub(crate) fn assert_protocol_parameters_unchanged(
+        &self,
+        transition_type: IvcTransitionType,
+    ) -> StmResult<()> {
         if !self.is_genesis()
+            && matches!(transition_type, IvcTransitionType::NextEpoch)
             && self.state().protocol_parameters != self.state().next_protocol_parameters
         {
             return Err(IvcProofError::ProtocolParametersChanged.into());

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/rolling_state.rs
@@ -266,7 +266,9 @@ mod tests {
     use rand_core::SeedableRng;
 
     use crate::{
-        circuits::halo2_ivc::types::EpochNumber,
+        circuits::halo2_ivc::{
+            embedded_assets::load_embedded_recursive_chain_state_asset, types::EpochNumber,
+        },
         signature_scheme::{BaseFieldElement, SchnorrSigningKey},
     };
 
@@ -323,6 +325,50 @@ mod tests {
         let genesis_signature = build_genesis_signature();
         let rolling_state = IvcRollingState::genesis(genesis_signature, &[]);
         assert!(rolling_state.is_genesis());
+    }
+
+    // The context guard is the first thing `IvcProver::prove` runs. It is tested directly here
+    // rather than through `prove` so the test stays fast: reaching `prove` would require building
+    // an `IvcSnarkProverSetup` (full keygen). With `genesis_bootstrap` now always supplied, a genesis
+    // `rolling_state` is the only remaining invalid context; both-`Some`/both-`None` are
+    // unrepresentable.
+    #[test]
+    fn ensure_advanceable_rolling_state_rejects_only_genesis_state() {
+        // A genesis signature is needed to build any rolling state; its value is irrelevant
+        // because the guard only inspects the step counter.
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let signing_key = SchnorrSigningKey::generate(&mut rng);
+        let genesis_signature = signing_key
+            .sign_standard(&[BaseFieldElement::from(1u64)], &mut rng)
+            .expect("genesis signature should be produced");
+
+        // `None` bootstraps from genesis internally: accepted.
+        IvcRollingState::ensure_advanceable_rolling_state(None)
+            .expect("None must be accepted (genesis bootstrap)");
+
+        // A genesis rolling state (`step_counter == 0`) must be rejected.
+        let genesis_state = IvcRollingState::genesis(genesis_signature, &[]);
+        assert!(genesis_state.is_genesis());
+        let err = IvcRollingState::ensure_advanceable_rolling_state(Some(&genesis_state))
+            .expect_err("genesis rolling state must be rejected");
+        assert_eq!(
+            err.downcast_ref::<IvcProofError>(),
+            Some(&IvcProofError::InvalidProvingContext),
+            "genesis rolling state must fail with InvalidProvingContext, got: {err}"
+        );
+
+        // A non-genesis rolling state (a previous step's output) is accepted.
+        let chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let advanced_state = IvcRollingState::new(
+            chain_state.state,
+            chain_state.ivc_proof,
+            chain_state.accumulator,
+            chain_state.genesis_signature,
+        );
+        assert!(!advanced_state.is_genesis());
+        IvcRollingState::ensure_advanceable_rolling_state(Some(&advanced_state))
+            .expect("a non-genesis rolling state must be accepted");
     }
 
     mod validate_transition {

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -58,6 +58,12 @@ pub use halo2_snark::{
     AggregateVerificationKeyForSnark, MERKLE_TREE_DEPTH_FOR_SNARK, SnarkProof, SnarkVerifierData,
 };
 
+#[cfg(feature = "future_snark")]
+pub(crate) use halo2_ivc_snark::IvcRollingState;
+#[cfg(all(test, feature = "future_snark"))]
+pub(crate) use halo2_ivc_snark::MockIvcOffCircuitChecker;
+#[cfg(all(test, feature = "future_snark"))]
+pub(crate) use halo2_snark::RIGID_SLOT_BYTES as SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES;
 #[cfg(all(test, feature = "future_snark"))]
 pub(crate) use halo2_snark::{MockSnarkAggregateSignatureProver, SnarkProverSetup};
 #[cfg(feature = "future_snark")]
@@ -67,13 +73,6 @@ pub(crate) use halo2_snark::{
 };
 
 #[cfg(all(test, feature = "future_snark"))]
-pub(crate) use halo2_snark::RIGID_SLOT_BYTES as SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES;
-
-#[cfg(feature = "future_snark")]
-pub(crate) use halo2_ivc_snark::IvcRollingState;
-
+pub(crate) use snark_prover_factory::MockSnarkProverFactory;
 #[cfg(feature = "future_snark")]
 pub(crate) use snark_prover_factory::{NonDeterministicSnarkProverFactory, SnarkProverFactory};
-
-#[cfg(all(test, feature = "future_snark"))]
-pub(crate) use snark_prover_factory::MockSnarkProverFactory;

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -7,14 +7,17 @@ use anyhow::Context;
 use anyhow::anyhow;
 
 #[cfg(all(feature = "future_snark", test))]
-use crate::proof_system::MockSnarkProverFactory;
+use crate::proof_system::{MockIvcOffCircuitChecker, MockSnarkProverFactory};
+
 #[cfg(feature = "future_snark")]
 use crate::{
     AggregateSignatureError, AncillaryProverData, AncillaryVerifierData,
     proof_system::{
         NonDeterministicSnarkProverFactory, SnarkAggregateSignatureProver, SnarkClerk,
         SnarkProverFactory, SnarkVerifierData,
-        halo2_ivc_snark::{IvcChainStepBundle, IvcVerifierData},
+        halo2_ivc_snark::{
+            IvcChainStepBundle, IvcOffCircuitChecker, IvcVerifierData, RealIvcOffCircuitChecker,
+        },
     },
 };
 use crate::{
@@ -40,6 +43,8 @@ pub struct Clerk<D: MembershipDigest> {
     /// A factory that returns the provers necessary to create the SNARK proofs
     #[cfg(feature = "future_snark")]
     snark_prover_factory: Arc<dyn SnarkProverFactory<D> + Send + Sync>,
+    #[cfg(feature = "future_snark")]
+    ivc_off_circuit_checker: Arc<dyn IvcOffCircuitChecker + Send + Sync>,
     phantom_data: PhantomData<D>,
 }
 
@@ -55,6 +60,8 @@ impl<D: MembershipDigest> Clerk<D> {
                 .then(|| SnarkClerk::new_clerk_from_signer(signer)),
             #[cfg(feature = "future_snark")]
             snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
+            #[cfg(feature = "future_snark")]
+            ivc_off_circuit_checker: Arc::new(RealIvcOffCircuitChecker),
             phantom_data: PhantomData,
         }
     }
@@ -75,6 +82,8 @@ impl<D: MembershipDigest> Clerk<D> {
             }),
             #[cfg(feature = "future_snark")]
             snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
+            #[cfg(feature = "future_snark")]
+            ivc_off_circuit_checker: Arc::new(RealIvcOffCircuitChecker),
             phantom_data: PhantomData,
         }
     }
@@ -88,8 +97,11 @@ impl<D: MembershipDigest> Clerk<D> {
     where
         D: Send + Sync + 'static,
     {
+        let mut ivc_off_circuit_checker = MockIvcOffCircuitChecker::new();
+        ivc_off_circuit_checker.expect_check().returning(|_, _, _| Ok(()));
         Self {
             snark_prover_factory: Arc::new(snark_prover_factory),
+            ivc_off_circuit_checker: Arc::new(ivc_off_circuit_checker),
             ..Self::new_clerk_from_signer(signer)
         }
     }
@@ -137,6 +149,15 @@ impl<D: MembershipDigest> Clerk<D> {
                 let snark_clerk = self
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
+
+                self.ivc_off_circuit_checker.check(
+                    msg,
+                    &snark_clerk
+                        .compute_aggregate_verification_key_for_snark::<D>()
+                        .get_merkle_tree_commitment()
+                        .root,
+                    &ancillary_input,
+                )?;
 
                 self.aggregate_signatures_for_ivc_snark(snark_clerk, sigs, msg, ancillary_input)
             }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -16,7 +16,7 @@ use crate::{
         NonDeterministicSnarkProverFactory, SnarkAggregateSignatureProver, SnarkClerk,
         SnarkProverFactory, SnarkVerifierData,
         halo2_ivc_snark::{
-            IvcChainStepBundle, IvcOffCircuitChecker, IvcVerifierData, RealIvcOffCircuitChecker,
+            IvcChainStepBundle, IvcOffCircuitChecker, IvcVerifierData, MithrilIvcOffCircuitChecker,
         },
     },
 };
@@ -44,7 +44,7 @@ pub struct Clerk<D: MembershipDigest> {
     #[cfg(feature = "future_snark")]
     snark_prover_factory: Arc<dyn SnarkProverFactory<D> + Send + Sync>,
     #[cfg(feature = "future_snark")]
-    ivc_off_circuit_checker: Arc<dyn IvcOffCircuitChecker + Send + Sync>,
+    ivc_off_circuit_checker: Arc<dyn IvcOffCircuitChecker<D> + Send + Sync>,
     phantom_data: PhantomData<D>,
 }
 
@@ -61,7 +61,7 @@ impl<D: MembershipDigest> Clerk<D> {
             #[cfg(feature = "future_snark")]
             snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
             #[cfg(feature = "future_snark")]
-            ivc_off_circuit_checker: Arc::new(RealIvcOffCircuitChecker),
+            ivc_off_circuit_checker: Arc::new(MithrilIvcOffCircuitChecker),
             phantom_data: PhantomData,
         }
     }
@@ -83,7 +83,7 @@ impl<D: MembershipDigest> Clerk<D> {
             #[cfg(feature = "future_snark")]
             snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
             #[cfg(feature = "future_snark")]
-            ivc_off_circuit_checker: Arc::new(RealIvcOffCircuitChecker),
+            ivc_off_circuit_checker: Arc::new(MithrilIvcOffCircuitChecker),
             phantom_data: PhantomData,
         }
     }
@@ -154,10 +154,7 @@ impl<D: MembershipDigest> Clerk<D> {
 
                 self.ivc_off_circuit_checker.off_circuit_check(
                     msg,
-                    &snark_clerk
-                        .compute_aggregate_verification_key_for_snark::<D>()
-                        .get_merkle_tree_commitment()
-                        .root,
+                    &snark_clerk.compute_aggregate_verification_key_for_snark::<D>(),
                     &ancillary_input,
                 )?;
 
@@ -405,12 +402,12 @@ mod tests {
             self
         }
 
-        fn without_snark_prover(mut self) -> Self {
+        fn without_snark_prover_call(mut self) -> Self {
             self.snark_behavior = SnarkProverBehavior::NeverCalled;
             self
         }
 
-        fn without_ivc_prover(mut self) -> Self {
+        fn without_ivc_prover_call(mut self) -> Self {
             self.ivc_behavior = IvcProverBehavior::NeverCalled;
             self
         }
@@ -490,15 +487,15 @@ mod tests {
 
         fn build_clerk_rejecting_checks(self, signer: &Signer<D>) -> Clerk<D> {
             let clerk = MockProverFactory::new()
-                .without_snark_prover()
-                .without_ivc_prover()
+                .without_snark_prover_call()
+                .without_ivc_prover_call()
                 .build_clerk(signer);
 
             let mut checker = MockIvcOffCircuitChecker::new();
             checker
                 .expect_off_circuit_check()
                 .once()
-                .return_once(|_, _, _| Err(anyhow!("synthetic rejection")));
+                .return_once(|_, _, _| Err(anyhow!("checker rejection")));
             Clerk {
                 ivc_off_circuit_checker: Arc::new(checker),
                 ..clerk
@@ -664,8 +661,8 @@ mod tests {
         let signature = signer.create_single_signature(&DUMMY_MESSAGE).unwrap();
 
         let clerk = MockProverFactory::new()
-            .without_snark_prover()
-            .without_ivc_prover()
+            .without_snark_prover_call()
+            .without_ivc_prover_call()
             .build_clerk(&signer);
 
         let (aggregate_signature, _ancillary_output) = clerk
@@ -703,7 +700,7 @@ mod tests {
         let signer = setup_single_party(PARAMS);
 
         let clerk = MockProverFactory::new()
-            .without_ivc_prover()
+            .without_ivc_prover_call()
             .snark_prover(SnarkProverBehavior::AggregatesSignaturesWithFunction(
                 Box::new(|actual_params| *actual_params == PARAMS),
             ))
@@ -721,7 +718,7 @@ mod tests {
         let signer = setup_single_party(PARAMS);
 
         let clerk = MockProverFactory::new()
-            .without_ivc_prover()
+            .without_ivc_prover_call()
             .snark_prover(SnarkProverBehavior::FailsToBuild("factory error"))
             .build_clerk(&signer);
 
@@ -735,7 +732,9 @@ mod tests {
     fn snark_aggregation_returns_verifier_data_from_prover_key() {
         let signer = setup_single_party(PARAMS);
 
-        let clerk = MockProverFactory::new().without_ivc_prover().build_clerk(&signer);
+        let clerk = MockProverFactory::new()
+            .without_ivc_prover_call()
+            .build_clerk(&signer);
 
         let (aggregate_signature, ancillary_output) =
             aggregate_snark(clerk, build_ancillary_input(None))
@@ -763,7 +762,7 @@ mod tests {
         let signer = setup_single_party(PARAMS);
 
         let clerk = MockProverFactory::new()
-            .without_ivc_prover()
+            .without_ivc_prover_call()
             .snark_prover(SnarkProverBehavior::FailsToAggregate("prover error"))
             .build_clerk(&signer);
 
@@ -901,7 +900,7 @@ mod tests {
 
         let clerk = MockProverFactory::new()
             .snark_prover(SnarkProverBehavior::FailsToAggregate("SNARK prover error"))
-            .without_ivc_prover()
+            .without_ivc_prover_call()
             .build_clerk(&signer);
 
         let err = aggregate_ivc_with_dummy_message(clerk, build_ancillary_input(None))
@@ -959,6 +958,6 @@ mod tests {
             )
             .expect_err("a rejected check must abort aggregation before any proving");
 
-        assert_eq!(err.to_string(), "synthetic rejection");
+        assert_eq!(err.to_string(), "checker rejection");
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -98,7 +98,9 @@ impl<D: MembershipDigest> Clerk<D> {
         D: Send + Sync + 'static,
     {
         let mut ivc_off_circuit_checker = MockIvcOffCircuitChecker::new();
-        ivc_off_circuit_checker.expect_check().returning(|_, _, _| Ok(()));
+        ivc_off_circuit_checker
+            .expect_off_circuit_check()
+            .returning(|_, _, _| Ok(()));
         Self {
             snark_prover_factory: Arc::new(snark_prover_factory),
             ivc_off_circuit_checker: Arc::new(ivc_off_circuit_checker),
@@ -150,7 +152,7 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
-                self.ivc_off_circuit_checker.check(
+                self.ivc_off_circuit_checker.off_circuit_check(
                     msg,
                     &snark_clerk
                         .compute_aggregate_verification_key_for_snark::<D>()
@@ -490,11 +492,11 @@ mod tests {
             let clerk = MockProverFactory::new()
                 .without_snark_prover()
                 .without_ivc_prover()
-                .build_clerk(&signer);
+                .build_clerk(signer);
 
             let mut checker = MockIvcOffCircuitChecker::new();
             checker
-                .expect_check()
+                .expect_off_circuit_check()
                 .once()
                 .return_once(|_, _, _| Err(anyhow!("synthetic rejection")));
             Clerk {

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -291,6 +291,8 @@ impl<D: MembershipDigest> Clerk<D> {
 #[cfg(test)]
 mod tests {
 
+    use std::sync::Arc;
+
     use anyhow::anyhow;
     use midnight_proofs::transcript::Blake2b256;
 
@@ -313,8 +315,8 @@ mod tests {
         },
         codec::{TryFromBytes, TryToBytes},
         proof_system::{
-            IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK, MockSnarkAggregateSignatureProver,
-            MockSnarkProverFactory, SnarkClerk,
+            IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK, MockIvcOffCircuitChecker,
+            MockSnarkAggregateSignatureProver, MockSnarkProverFactory, SnarkClerk,
             halo2_ivc_snark::{
                 IvcChainStepBundle, IvcProof, IvcVerifierData, MockIvcChainProver,
                 build_standard_rolling_state,
@@ -482,6 +484,23 @@ mod tests {
             }
 
             Clerk::new_clerk_from_signer_with_mock_prover_factory(signer, factory)
+        }
+
+        fn build_clerk_rejecting_checks(self, signer: &Signer<D>) -> Clerk<D> {
+            let clerk = MockProverFactory::new()
+                .without_snark_prover()
+                .without_ivc_prover()
+                .build_clerk(&signer);
+
+            let mut checker = MockIvcOffCircuitChecker::new();
+            checker
+                .expect_check()
+                .once()
+                .return_once(|_, _, _| Err(anyhow!("synthetic rejection")));
+            Clerk {
+                ivc_off_circuit_checker: Arc::new(checker),
+                ..clerk
+            }
         }
     }
 
@@ -922,5 +941,22 @@ mod tests {
             Some(&AggregationError::MissingIvcRollingStateInAncillaryProverData),
             "missing IVC rolling state must be rejected, got: {err}"
         );
+    }
+
+    #[test]
+    fn ivc_snark_rejects_before_generating_certificate_proof_when_check_fails() {
+        let signer = setup_single_party(PARAMS);
+        let clerk = MockProverFactory::new().build_clerk_rejecting_checks(&signer);
+
+        let err = clerk
+            .aggregate_signatures_with_type(
+                &[],
+                &DUMMY_MESSAGE,
+                AggregateSignatureType::IvcSnark,
+                build_ancillary_input(None),
+            )
+            .expect_err("a rejected check must abort aggregation before any proving");
+
+        assert_eq!(err.to_string(), "synthetic rejection");
     }
 }


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes adds CPU-side (off-circuit) validation for the IVC Halo2 proving pipeline, so malformed requests are rejected before paying for the certificate proof (and, where applicable, before the recursive IVC proof too), instead of only failing inside the circuit proof generation.

## Changes
- New `IvcOffCircuitChecker` trait (proof_system/ivc_halo2_snark/interface.rs), used by the `Clerk`. 
- `MithrilIvcOffCircuitChecker` (new off_circuit_checker.rs), the production implementation with one checking function:
  - `off_circuit_check`: the single entry point Clerk calls that performs all the pre proofs off circuit checks.
- `assert_protocol_parameters_unchanged`: moved from free function to `IvcRollingState` impl block, only returns an error in `NextEpoch` transition if the protocol parameters are about to change
- Wired into `Clerk::aggregate_signatures_with_type`'s `IvcSnark` arm as a single call. `IvcChainInput::try_new` keeps its own (now partially redundant) validation as defense-in-depth for now.
- Added the accumulator pairing-check guard at the end of `build_next_accumulator`.
- `ensure_advanceable_rolling_state`: renamed to `ensure_advanceable` and moved from free function to `IvcRollingState` impl 

## Off-circuit checks performed by `off_circuit_check`

| # | Check | Applies to |
|---|---|---|
| 1 | Genesis verification key is present | every request |
| 2 | Genesis verification key is structurally valid | every request |
| 3 | Genesis message preimage decodes to a valid hash | every request |
| 4 | Genesis bootstrap input is well-formed (signature present, preimage exactly `PREIMAGE_SIZE` bytes) | every request |
| 5 | An existing rolling state is not itself genesis-shaped | every request |
| 6 | Protocol message preimage is exactly `PREIMAGE_SIZE` bytes | every request |
| 7 | Transition classification (same-epoch / next-epoch) and certificate/rolling-state consistency (Merkle-tree commitment, next-fields matching, step counter) | non-genesis only |
| 8 | Protocol parameters do not diverge across a next-epoch transition — gated specifically to the transition that would promote `next_protocol_parameters`, so same-epoch certificates in the epoch where a divergence was announced still succeed | non-genesis only |
| 9 | Genesis signature verifies cryptographically | genesis only |
| 10 | First real certificate's epoch is `genesis_epoch + 1`, and its Merkle-tree commitment matches the genesis-announced lookahead | genesis only |
| 11 | Certificate message hash matches the supplied preimage | every request |



## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3381 
