### PR TITLE
feat(stm): cache the circuit keys and reuse the prover setups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.16", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.17", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.17 (09-11-2026)
+
+### Changed
+
+- Loaded the SNARK prover setups once per process instead of once per aggregation, through a cache the prover factory reads, which takes the SRS read and the key deserialization out of every signing round at the cost of keeping them resident. Reuse is a policy carried by `NonDeterministicSnarkProverFactory::new`, and a cached setup is only served to the protocol parameters and Merkle tree depth it was derived for.
+
+### Fixed
+
+- Keyed the on-disk circuit key cache by configuration, its entries having been compared against the embedded production verifying key: a node running any other protocol parameters always found them stale and re-derived both key pairs from the SRS at every aggregation.
+
 ## 0.12.14 (09-09-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.16"
+version = "0.12.17"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/mod.rs
+++ b/mithril-stm/src/circuits/halo2/mod.rs
@@ -11,6 +11,8 @@
 //! - inline `#[cfg(test)]` blocks in `gadgets/*` and `adapters`: focused regression checks
 //! - `tests/test_helpers`: shared harness for focused gadget tests
 
+use crate::Parameters;
+
 pub mod adapters;
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod witness_assignments;
@@ -34,6 +36,13 @@ pub mod bench;
 
 #[cfg(test)]
 pub(crate) mod tests;
+
+/// STM parameters the production circuit verification keys are derived from.
+pub(crate) const STM_PARAMETERS_FOR_PRODUCTION: Parameters = Parameters {
+    m: 16948,
+    k: 1944,
+    phi_f: 0.2,
+};
 
 /// Circuit verification key of the non-recursive circuit used for production.
 /// This key is generated using the Midnight's secure SRS and the following

--- a/mithril-stm/src/circuits/halo2/tests/verification_key_computation.rs
+++ b/mithril-stm/src/circuits/halo2/tests/verification_key_computation.rs
@@ -5,18 +5,11 @@ use crate::{
     MERKLE_TREE_DEPTH_FOR_SNARK, Parameters, StmResult,
     circuits::{
         halo2::{
-            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::CertificateCircuit,
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, STM_PARAMETERS_FOR_PRODUCTION,
+            circuit::CertificateCircuit,
         },
         trusted_setup::TrustedSetupProvider,
     },
-};
-
-/// Constant representing the current STM parameters used for production,
-/// i.e. parameters that guarantee the security of the protocol
-const STM_PARAMETERS_FOR_PRODUCTION: Parameters = Parameters {
-    m: 16948,
-    k: 1944,
-    phi_f: 0.2,
 };
 
 /// Derive the non-recursive circuit verification key from the production SRS and the given

--- a/mithril-stm/src/circuits/key_provider.rs
+++ b/mithril-stm/src/circuits/key_provider.rs
@@ -16,17 +16,24 @@ use anyhow::Context;
 use midnight_curves::Bls12;
 use midnight_proofs::poly::kzg::params::ParamsKZG;
 use rand_core::{OsRng, RngCore};
+use sha2::{Digest, Sha256};
 
 use crate::codec::{TryFromBytes, TryToBytes};
-use crate::{Parameters, StmResult};
+use crate::{MERKLE_TREE_DEPTH_FOR_SNARK, Parameters, StmResult};
 
 use super::halo2::circuit::CertificateCircuit;
 use super::halo2_ivc::keys::RecursiveCircuitKeyGenerator;
 use super::key_generator::KeyGenerator;
+use super::trusted_setup::MIDNIGHT_SRS_HASH_K22;
 use super::{
-    MITHRIL_CIRCUIT_CACHE_FOLDER, halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+    MITHRIL_CIRCUIT_CACHE_FOLDER,
+    halo2::{NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, STM_PARAMETERS_FOR_PRODUCTION},
     halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
 };
+
+/// Bumped whenever the cache layout or the fingerprint inputs change, so an entry written by an
+/// earlier scheme is never reused.
+const CACHE_SCHEMA_VERSION: &[u8] = b"v1";
 
 /// Outcome of inspecting the on-disk key cache for a complete, fresh key pair.
 enum CacheState {
@@ -40,6 +47,70 @@ enum CacheState {
     },
     /// Nothing usable on disk: absent, stale, or a partial write.
     Empty,
+}
+
+/// Cache identity of a circuit configuration, which the derived keys depend on.
+///
+/// The production configuration keeps a stable directory and is validated against the embedded
+/// production verifying key. Any other configuration derives keys the embedded key would reject, so
+/// it gets a directory of its own, keyed by a fingerprint of the configuration, and the entry found
+/// there is trusted.
+enum CircuitCacheIdentity {
+    /// The configuration the embedded production verifying keys were derived from.
+    Production,
+    /// Any other configuration, identified by the hex digest of its fingerprint.
+    Fingerprinted(String),
+}
+
+impl CircuitCacheIdentity {
+    /// Identifies the configuration made of `parameters` and `merkle_tree_depth`.
+    ///
+    /// The fingerprint also folds in the cache schema version, the embedded production verifying key
+    /// and the SRS the keys are derived from, so an entry is never reused across a layout change, a
+    /// circuit change or an SRS change. The production verifying key stands for the circuit itself:
+    /// it changes with the circuit and only with it, which no configuration outside production can
+    /// check against.
+    fn for_configuration(parameters: &Parameters, merkle_tree_depth: u32) -> StmResult<Self> {
+        if parameters == &STM_PARAMETERS_FOR_PRODUCTION
+            && merkle_tree_depth == MERKLE_TREE_DEPTH_FOR_SNARK
+        {
+            return Ok(Self::Production);
+        }
+
+        let mut hasher = Sha256::new();
+        for input in [
+            CACHE_SCHEMA_VERSION,
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            MIDNIGHT_SRS_HASH_K22.as_bytes(),
+            parameters.to_bytes()?.as_slice(),
+            &merkle_tree_depth.to_le_bytes(),
+        ] {
+            hasher.update((input.len() as u64).to_le_bytes());
+            hasher.update(input);
+        }
+
+        Ok(Self::Fingerprinted(hex::encode(hasher.finalize())))
+    }
+
+    /// Name of the directory holding the keys of `circuit_name` for this configuration.
+    fn directory_name(&self, circuit_name: &str) -> String {
+        match self {
+            Self::Production => circuit_name.to_string(),
+            Self::Fingerprinted(fingerprint) => format!("{circuit_name}-{fingerprint}"),
+        }
+    }
+
+    /// Verifying key a cached entry is validated against: the embedded production key for the
+    /// production configuration, none for the others, which their own directory already isolates.
+    fn expected_verification_key(
+        &self,
+        production_verification_key: &'static [u8],
+    ) -> &'static [u8] {
+        match self {
+            Self::Production => production_verification_key,
+            Self::Fingerprinted(_) => &[],
+        }
+    }
 }
 
 /// Provides a key generator's verifying and proving keys: an on-disk cache (with staleness detection)
@@ -233,35 +304,45 @@ impl<G: KeyGenerator> KeyProvider<G> {
 }
 
 impl KeyProvider<CertificateCircuit> {
-    /// Production certificate-circuit provider: builds the circuit from `parameters`, roots the
-    /// cache at the temporary directory, and validates against the embedded production verifying key.
+    /// Certificate-circuit provider: builds the circuit from `parameters`, roots the cache at the
+    /// temporary directory, and isolates the entry by [`CircuitCacheIdentity`], so the production
+    /// configuration is validated against the embedded production verifying key while any other
+    /// configuration caches into a directory of its own.
     pub(crate) fn for_non_recursive_circuit(
         parameters: &Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Self> {
+        let identity = CircuitCacheIdentity::for_configuration(parameters, merkle_tree_depth)?;
         let circuit = CertificateCircuit::try_new(parameters, merkle_tree_depth)?;
+
         Ok(Self::new(
             std::env::temp_dir(),
-            "non-recursive-keys",
-            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            &identity.directory_name("non-recursive-keys"),
+            identity
+                .expected_verification_key(NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION),
             circuit,
         ))
     }
 }
 
 impl KeyProvider<RecursiveCircuitKeyGenerator> {
-    /// Production recursive-circuit provider: wraps the non-recursive key provider the recursive
-    /// circuit is built from, roots the cache at the temporary directory, and validates against the
-    /// embedded production verifying key.
+    /// Recursive-circuit provider: wraps the non-recursive key provider the recursive circuit is
+    /// built from, roots the cache at the temporary directory, and isolates the entry by the
+    /// [`CircuitCacheIdentity`] of the configuration the wrapped provider was built for, the recursive
+    /// keys being derived from the non-recursive ones.
     pub(crate) fn for_recursive_circuit(
         non_recursive_key_provider: KeyProvider<CertificateCircuit>,
-    ) -> Self {
-        Self::new(
+        parameters: &Parameters,
+        merkle_tree_depth: u32,
+    ) -> StmResult<Self> {
+        let identity = CircuitCacheIdentity::for_configuration(parameters, merkle_tree_depth)?;
+
+        Ok(Self::new(
             std::env::temp_dir(),
-            "recursive-keys",
-            RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            &identity.directory_name("recursive-keys"),
+            identity.expected_verification_key(RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION),
             RecursiveCircuitKeyGenerator::new(non_recursive_key_provider),
-        )
+        ))
     }
 }
 
@@ -287,10 +368,13 @@ mod tests {
     use rand_core::SeedableRng;
 
     use super::{CacheState, KeyGenerator, KeyProvider};
-    use crate::Parameters;
     use crate::StmResult;
-    use crate::circuits::halo2::circuit::CertificateCircuit;
+    use crate::circuits::halo2::{
+        NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, STM_PARAMETERS_FOR_PRODUCTION,
+        circuit::CertificateCircuit,
+    };
     use crate::codec::{TryFromBytes, TryToBytes};
+    use crate::{MERKLE_TREE_DEPTH_FOR_SNARK, Parameters};
 
     /// Key backed by raw bytes, so the provider mechanics can be tested without real keygen.
     #[derive(Clone, Debug, PartialEq)]
@@ -618,5 +702,151 @@ mod tests {
             "proving key path must be rooted under the circuit cache folder"
         );
         fs::remove_dir_all(&base_dir).ok();
+    }
+
+    fn parameters_outside_production() -> Parameters {
+        Parameters {
+            m: 9,
+            k: 5,
+            phi_f: 0.95,
+        }
+    }
+
+    fn certificate_key_provider(
+        parameters: &Parameters,
+        merkle_tree_depth: u32,
+    ) -> KeyProvider<CertificateCircuit> {
+        KeyProvider::for_non_recursive_circuit(parameters, merkle_tree_depth).unwrap()
+    }
+
+    #[test]
+    fn production_configuration_caches_under_the_stable_directory() {
+        let provider =
+            certificate_key_provider(&STM_PARAMETERS_FOR_PRODUCTION, MERKLE_TREE_DEPTH_FOR_SNARK);
+
+        assert!(
+            provider
+                .verification_key_path()
+                .ends_with("mithril-circuit/non-recursive-keys/verification-key"),
+            "the production configuration must keep the stable cache directory, got {:?}",
+            provider.verification_key_path()
+        );
+    }
+
+    #[test]
+    fn production_configuration_only_trusts_the_embedded_verification_key() {
+        let provider =
+            certificate_key_provider(&STM_PARAMETERS_FOR_PRODUCTION, MERKLE_TREE_DEPTH_FOR_SNARK);
+
+        assert!(
+            !provider.is_stale(NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION),
+            "the embedded production verifying key must be accepted"
+        );
+        assert!(
+            provider.is_stale(b"another-verification-key"),
+            "a cached key that is not the embedded production one must be recomputed"
+        );
+    }
+
+    #[test]
+    fn configuration_outside_production_caches_under_its_own_directory() {
+        let provider = certificate_key_provider(
+            &parameters_outside_production(),
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        );
+        let directory = provider.verification_key_path().parent().unwrap().to_path_buf();
+
+        assert!(
+            directory
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("non-recursive-keys-"),
+            "a configuration outside production must be fingerprinted, got {directory:?}"
+        );
+        assert!(
+            directory.parent().unwrap().ends_with("mithril-circuit"),
+            "the fingerprinted directory must stay under the circuit cache folder, got {directory:?}"
+        );
+    }
+
+    #[test]
+    fn configuration_outside_production_trusts_the_cached_verification_key() {
+        let provider = certificate_key_provider(
+            &parameters_outside_production(),
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        );
+
+        assert!(
+            !provider.is_stale(b"any-cached-verification-key"),
+            "a fingerprinted directory isolates the configuration, so its entry must be trusted"
+        );
+    }
+
+    #[test]
+    fn distinct_configurations_outside_production_do_not_share_a_directory() {
+        let provider = certificate_key_provider(
+            &parameters_outside_production(),
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        );
+        let other_parameters = certificate_key_provider(
+            &Parameters {
+                m: 10,
+                k: 5,
+                phi_f: 0.95,
+            },
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        );
+        let other_depth = certificate_key_provider(
+            &parameters_outside_production(),
+            MERKLE_TREE_DEPTH_FOR_SNARK + 1,
+        );
+
+        assert_ne!(
+            provider.verification_key_path(),
+            other_parameters.verification_key_path(),
+            "distinct protocol parameters must not share a cache directory"
+        );
+        assert_ne!(
+            provider.verification_key_path(),
+            other_depth.verification_key_path(),
+            "distinct Merkle tree depths must not share a cache directory"
+        );
+    }
+
+    #[test]
+    fn recursive_circuit_follows_the_configuration_of_its_certificate_circuit() {
+        let production = KeyProvider::for_recursive_circuit(
+            certificate_key_provider(&STM_PARAMETERS_FOR_PRODUCTION, MERKLE_TREE_DEPTH_FOR_SNARK),
+            &STM_PARAMETERS_FOR_PRODUCTION,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )
+        .unwrap();
+        let outside_production = KeyProvider::for_recursive_circuit(
+            certificate_key_provider(
+                &parameters_outside_production(),
+                MERKLE_TREE_DEPTH_FOR_SNARK,
+            ),
+            &parameters_outside_production(),
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )
+        .unwrap();
+
+        assert!(
+            production
+                .verification_key_path()
+                .ends_with("mithril-circuit/recursive-keys/verification-key"),
+            "the production configuration must keep the stable cache directory, got {:?}",
+            production.verification_key_path()
+        );
+        assert_ne!(
+            production.verification_key_path(),
+            outside_production.verification_key_path(),
+            "the recursive keys of a configuration outside production must be isolated"
+        );
+        assert!(
+            !outside_production.is_stale(b"any-cached-verification-key"),
+            "a fingerprinted directory isolates the configuration, so its entry must be trusted"
+        );
     }
 }

--- a/mithril-stm/src/circuits/trusted_setup.rs
+++ b/mithril-stm/src/circuits/trusted_setup.rs
@@ -20,7 +20,7 @@ use {rand_chacha::ChaCha20Rng, rand_core::SeedableRng, std::fs::create_dir_all};
 ///
 /// If the degree of the SRS used were to change, this hash would need to be updated using
 /// the proper value available here: https://github.com/midnightntwrk/midnight-trusted-setup/blob/main/MIDNIGHT_SRS_CATALOG.md
-const MIDNIGHT_SRS_HASH_K22: &str =
+pub(crate) const MIDNIGHT_SRS_HASH_K22: &str =
     "e8ad5eed936d657a0fb59d2a55ba19f81a3083bb3554ef88f464f5377e9b2c2f";
 /// Constant storing URL to download the SRS of degree 22 used to create proof in production
 const MIDNIGHT_SRS_URL_K22: &str = "https://srs.midnight.network/midnight-srs-2p22";

--- a/mithril-stm/src/circuits/verification_key_digest.rs
+++ b/mithril-stm/src/circuits/verification_key_digest.rs
@@ -23,7 +23,9 @@ use crate::circuits::halo2_ivc::{
     KZGCommitmentScheme, NativeField, PairingEngine,
     RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, VerifyingKey,
 };
-use crate::proof_system::{NonDeterministicSnarkProverFactory, SnarkProverFactory};
+use crate::proof_system::{
+    NonDeterministicSnarkProverFactory, SnarkProverFactory, SnarkProverSetupReuse,
+};
 use crate::signature_scheme::{
     BaseFieldElement, DOMAIN_SEPARATION_TAG_CIRCUIT_VERIFICATION_KEY_DIGEST,
     compute_poseidon_digest,
@@ -91,10 +93,13 @@ impl CircuitVerificationKeyDigest {
     ///
     /// The key is derived through the same prover the clerk uses to aggregate signatures, so the
     /// digest matches the one carried by the certificates produced with these parameters.
+    ///
+    /// The setup is not reused across calls: this computes a digest for the parameters it is given,
+    /// which are not necessarily the ones the process signs with, and only the verifying key is kept.
     pub fn compute_for_certificate_circuit(parameters: &Parameters) -> StmResult<Self> {
         let prover =
             SnarkProverFactory::<MithrilMembershipDigest>::snark_aggregate_signature_prover(
-                &NonDeterministicSnarkProverFactory,
+                &NonDeterministicSnarkProverFactory::new(SnarkProverSetupReuse::Disabled),
                 parameters,
             )?;
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/mod.rs
@@ -19,7 +19,6 @@ pub(crate) use proof::{IvcChainStepBundle, IvcProof, IvcProver};
 pub(crate) use prover_input::IvcProverInput;
 #[cfg(all(test, feature = "future_snark"))]
 pub(crate) use prover_input_helpers::tests::build_standard_rolling_state;
-#[cfg(feature = "benchmark-internals")]
 pub(crate) use prover_setup::IvcProverSetup;
 pub(crate) use rolling_state::{IvcRollingState, IvcTransitionType};
 pub(crate) use verifier_setup::{IvcVerifierData, IvcVerifierSetup};

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -559,7 +559,11 @@ impl IvcProver<OsRng> {
         let trusted_setup_provider = TrustedSetupProvider::default();
         let certificate_key_provider =
             KeyProvider::for_non_recursive_circuit(parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
-        let recursive_key_provider = KeyProvider::for_recursive_circuit(certificate_key_provider);
+        let recursive_key_provider = KeyProvider::for_recursive_circuit(
+            certificate_key_provider,
+            parameters,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )?;
         let ivc_setup = IvcProverSetup::load(&trusted_setup_provider, &recursive_key_provider)?;
 
         Ok(Self {

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/proof.rs
@@ -28,8 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AggregateVerificationKeyForSnark, AggregationError, AncillaryGenesisData, AncillaryProofInput,
-    BaseFieldElement, MERKLE_TREE_DEPTH_FOR_SNARK, MembershipDigest, Parameters, SnarkProof,
-    StmResult,
+    BaseFieldElement, MembershipDigest, SnarkProof, StmResult,
     circuits::{
         halo2::{keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase},
         halo2_ivc::{
@@ -40,8 +39,6 @@ use crate::{
             state::{Global, State},
             types::{CertificateProofBytes, IvcProofBytes, MessageHash, ProtocolMessagePreimage},
         },
-        key_provider::KeyProvider,
-        trusted_setup::TrustedSetupProvider,
     },
     codec,
     proof_system::halo2_ivc_snark::{
@@ -553,23 +550,12 @@ impl<R: RngCore + CryptoRng> IvcProver<R> {
 }
 
 impl IvcProver<OsRng> {
-    /// Loads the IVC setup from the trusted setup and the recursive key provider
-    /// derived from `parameters` and `MERKLE_TREE_DEPTH_FOR_SNARK`.
-    pub(crate) fn try_new_non_deterministic(parameters: &Parameters) -> StmResult<Self> {
-        let trusted_setup_provider = TrustedSetupProvider::default();
-        let certificate_key_provider =
-            KeyProvider::for_non_recursive_circuit(parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
-        let recursive_key_provider = KeyProvider::for_recursive_circuit(
-            certificate_key_provider,
-            parameters,
-            MERKLE_TREE_DEPTH_FOR_SNARK,
-        )?;
-        let ivc_setup = IvcProverSetup::load(&trusted_setup_provider, &recursive_key_provider)?;
-
-        Ok(Self {
-            ivc_setup: Arc::new(ivc_setup),
+    /// Creates a prover over `ivc_setup`, which the factory owns the reuse of.
+    pub(crate) fn new_non_deterministic(ivc_setup: Arc<IvcProverSetup>) -> Self {
+        Self {
+            ivc_setup,
             rng: OsRng,
-        })
+        }
     }
 }
 

--- a/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/halo2_ivc_snark/prover_setup.rs
@@ -11,19 +11,14 @@ use midnight_proofs::poly::kzg::{
 };
 
 #[cfg(test)]
-use crate::{
-    Parameters,
-    circuits::{
-        halo2::{
-            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::CertificateCircuit,
-        },
-        halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-        test_utils::file_mutex::FileMutex,
-        trusted_setup::UNSAFE_SRS_SEED,
-    },
+use crate::circuits::{
+    halo2::{NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::CertificateCircuit},
+    halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+    test_utils::file_mutex::FileMutex,
+    trusted_setup::UNSAFE_SRS_SEED,
 };
 use crate::{
-    StmResult,
+    MERKLE_TREE_DEPTH_FOR_SNARK, Parameters, StmResult,
     circuits::{
         halo2::{keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase},
         halo2_ivc::{
@@ -84,6 +79,21 @@ pub(crate) struct IvcProverSetup {
 }
 
 impl IvcProverSetup {
+    /// Builds the production trusted setup provider and recursive key provider derived from
+    /// `parameters` and [`MERKLE_TREE_DEPTH_FOR_SNARK`], then delegates to [`Self::load`].
+    pub(crate) fn try_new(parameters: &Parameters) -> StmResult<Self> {
+        let trusted_setup_provider = TrustedSetupProvider::default();
+        let certificate_key_provider =
+            KeyProvider::for_non_recursive_circuit(parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
+        let recursive_key_provider = KeyProvider::for_recursive_circuit(
+            certificate_key_provider,
+            parameters,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )?;
+
+        Self::load(&trusted_setup_provider, &recursive_key_provider)
+    }
+
     /// Derives the full IVC setup around a single SRS loaded once.
     ///
     /// Loads the SRS and downsizes it in place to [`RECURSIVE_CIRCUIT_DEGREE`] (stored for

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 use anyhow::Context;
 use midnight_circuits::hash::poseidon::PoseidonState;
@@ -163,26 +163,23 @@ impl<D: MembershipDigest> SnarkProof<D> {
 /// Holds the pre-computed SNARK setup and exposes proof generation.
 ///
 /// The type parameter `R` selects the randomness source used during proof generation.
-/// Use `try_new_non_deterministic` for production (`OsRng`) and `try_new_deterministic` for
+/// Use `new_non_deterministic` for production (`OsRng`) and `try_new_deterministic` for
 /// reproducible tests.
 pub struct SnarkProver<R: RngCore + CryptoRng> {
-    setup: SnarkProverSetup,
+    setup: Arc<SnarkProverSetup>,
     rng: R,
 }
 
 impl SnarkProver<rand_core::OsRng> {
-    /// Create a new prover with a non-deterministic randomness source (`OsRng`).
+    /// Create a new prover with a non-deterministic randomness source (`OsRng`) over `setup`.
     ///
-    /// This is the constructor intended for production use.
-    pub fn try_new_non_deterministic(
-        parameters: &Parameters,
-        merkle_tree_depth: u32,
-    ) -> StmResult<Self> {
-        Ok(Self {
-            setup: SnarkProverSetup::try_new(parameters, merkle_tree_depth)
-                .with_context(|| "Failed to initialize SNARK setup (SRS, circuit, keys)")?,
+    /// This is the constructor intended for production use. The setup is provided by the factory,
+    /// which owns whether it is reused across aggregations.
+    pub fn new_non_deterministic(setup: Arc<SnarkProverSetup>) -> Self {
+        Self {
+            setup,
             rng: rand_core::OsRng,
-        })
+        }
     }
 }
 
@@ -191,7 +188,7 @@ impl SnarkProver<ChaCha20Rng> {
     /// Create a new prover with a deterministic randomness source seeded from `seed` (for tests only).
     pub fn try_new_deterministic(seed: [u8; 32], setup: SnarkProverSetup) -> StmResult<Self> {
         Ok(Self {
-            setup,
+            setup: Arc::new(setup),
             rng: ChaCha20Rng::from_seed(seed),
         })
     }
@@ -549,6 +546,8 @@ mod tests {
     }
 
     mod golden {
+        use std::sync::Arc;
+
         use super::*;
         use crate::{
             AggregateSignature, AggregateVerificationKey, AncillaryVerifierData, Clerk,
@@ -609,9 +608,8 @@ mod tests {
             let message = vec![1u8; 32];
             let signatures: Vec<SingleSignature> =
                 signers.into_iter().map(|s| s.sign(&message).unwrap()).collect();
-            let mut prover =
-                SnarkProver::try_new_non_deterministic(&params, MERKLE_TREE_DEPTH_FOR_SNARK)
-                    .unwrap();
+            let setup = SnarkProverSetup::try_new(&params, MERKLE_TREE_DEPTH_FOR_SNARK).unwrap();
+            let mut prover = SnarkProver::new_non_deterministic(Arc::new(setup));
 
             let proof: SnarkProof<MithrilMembershipDigest> =
                 prover.aggregate_signatures(&clerk, &signatures, &message).unwrap();

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -21,6 +21,8 @@ mod concatenation;
 mod halo2_snark;
 #[cfg(feature = "future_snark")]
 mod snark_prover_factory;
+#[cfg(feature = "future_snark")]
+mod snark_setup_cache;
 
 /// Serialized `ParamsVerifierKZG` (i.e. `s_g2`) from the Midnight production trusted SRS.
 ///
@@ -76,3 +78,5 @@ pub(crate) use halo2_snark::{
 pub(crate) use snark_prover_factory::MockSnarkProverFactory;
 #[cfg(feature = "future_snark")]
 pub(crate) use snark_prover_factory::{NonDeterministicSnarkProverFactory, SnarkProverFactory};
+#[cfg(feature = "future_snark")]
+pub(crate) use snark_setup_cache::SnarkProverSetupReuse;

--- a/mithril-stm/src/proof_system/snark_prover_factory.rs
+++ b/mithril-stm/src/proof_system/snark_prover_factory.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use crate::{
     MERKLE_TREE_DEPTH_FOR_SNARK, MembershipDigest, Parameters, StmResult,
     proof_system::{
-        SnarkAggregateSignatureProver, SnarkProver,
+        SnarkAggregateSignatureProver, SnarkProver, SnarkProverSetupReuse,
         halo2_ivc_snark::{IvcChainProver, IvcProver},
     },
 };
@@ -26,21 +26,34 @@ pub(crate) trait SnarkProverFactory<D: MembershipDigest>: Debug {
 }
 
 /// Production factory: `SnarkProver<OsRng>` and `IvcProver<OsRng>` over the trusted setup.
-#[derive(Debug, Default)]
-pub(crate) struct NonDeterministicSnarkProverFactory;
+#[derive(Debug)]
+pub(crate) struct NonDeterministicSnarkProverFactory {
+    /// Whether the setups handed to the provers are reused across aggregations.
+    setup_reuse: SnarkProverSetupReuse,
+}
+
+impl NonDeterministicSnarkProverFactory {
+    /// Factory resolving the setups it hands to the provers through `setup_reuse`.
+    pub(crate) fn new(setup_reuse: SnarkProverSetupReuse) -> Self {
+        Self { setup_reuse }
+    }
+}
 
 impl<D: MembershipDigest> SnarkProverFactory<D> for NonDeterministicSnarkProverFactory {
     fn snark_aggregate_signature_prover(
         &self,
         parameters: &Parameters,
     ) -> StmResult<Box<dyn SnarkAggregateSignatureProver<D>>> {
-        Ok(Box::new(SnarkProver::try_new_non_deterministic(
-            parameters,
-            MERKLE_TREE_DEPTH_FOR_SNARK,
-        )?))
+        let setup = self
+            .setup_reuse
+            .certificate_setup(parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
+
+        Ok(Box::new(SnarkProver::new_non_deterministic(setup)))
     }
 
     fn ivc_chain_prover(&self, parameters: &Parameters) -> StmResult<Box<dyn IvcChainProver<D>>> {
-        Ok(Box::new(IvcProver::try_new_non_deterministic(parameters)?))
+        let setup = self.setup_reuse.ivc_setup(parameters)?;
+
+        Ok(Box::new(IvcProver::new_non_deterministic(setup)))
     }
 }

--- a/mithril-stm/src/proof_system/snark_setup_cache.rs
+++ b/mithril-stm/src/proof_system/snark_setup_cache.rs
@@ -5,14 +5,14 @@
 //! loads each setup once for the lifetime of the process, at the cost of keeping the SRS and the
 //! proving keys resident.
 //!
-//! A process only ever needs one setup: the circuit is built from the protocol parameters, and
-//! changing them changes the embedded circuit verification keys, so it takes a new release of the
-//! node rather than a new epoch.
+//! Each slot holds the setup of one configuration at a time. The circuit is built from the protocol
+//! parameters, so a caller asking for other parameters is never served a setup derived for the ones
+//! it did not ask for: the setup is loaded again and the previous one released.
 
 use std::sync::{Arc, Mutex, PoisonError};
 
 use crate::{
-    Parameters, StmResult,
+    MERKLE_TREE_DEPTH_FOR_SNARK, Parameters, StmResult,
     proof_system::{halo2_ivc_snark::IvcProverSetup, halo2_snark::SnarkProverSetup},
 };
 
@@ -22,10 +22,30 @@ static CERTIFICATE_SETUP: SetupSlot<SnarkProverSetup> = SetupSlot::new();
 /// The IVC setup of this process.
 static IVC_SETUP: SetupSlot<IvcProverSetup> = SetupSlot::new();
 
-/// A setup, loaded at most once and shared by every caller that asks for it.
+/// The configuration a setup was loaded for, which its keys only fit.
+#[derive(PartialEq, Eq)]
+struct SetupCacheKey {
+    /// Serialized protocol parameters.
+    parameters: Vec<u8>,
+    /// Merkle tree depth of the certificate circuit.
+    merkle_tree_depth: u32,
+}
+
+impl SetupCacheKey {
+    /// Identifies the configuration made of `parameters` and `merkle_tree_depth`.
+    fn try_new(parameters: &Parameters, merkle_tree_depth: u32) -> StmResult<Self> {
+        Ok(Self {
+            parameters: parameters.to_bytes()?,
+            merkle_tree_depth,
+        })
+    }
+}
+
+/// A setup and the configuration it was loaded for, shared by every caller asking for that same
+/// configuration.
 struct SetupSlot<T> {
-    /// The setup, absent until it has been loaded.
-    setup: Mutex<Option<Arc<T>>>,
+    /// The setup with its configuration, absent until one has been loaded.
+    setup: Mutex<Option<(SetupCacheKey, Arc<T>)>>,
 }
 
 impl<T> SetupSlot<T> {
@@ -36,18 +56,27 @@ impl<T> SetupSlot<T> {
         }
     }
 
-    /// Returns the setup, loading it with `load` if this is the first caller.
+    /// Returns the setup of `key`, loading it with `load` when the slot holds another configuration
+    /// or none yet.
     ///
-    /// Callers wait for that one load instead of racing through the expensive path. A failed load
-    /// leaves the slot empty and is retried by the next caller.
-    fn get_or_load(&self, load: impl FnOnce() -> StmResult<T>) -> StmResult<Arc<T>> {
+    /// Callers of one configuration wait for its single load instead of racing through the expensive
+    /// path. A configuration change loads again and releases the previous setup, so a process never
+    /// proves with keys derived for other parameters, nor keeps every configuration it has seen
+    /// resident. A failed load leaves the slot empty and is retried by the next caller.
+    fn get_or_load(
+        &self,
+        key: SetupCacheKey,
+        load: impl FnOnce() -> StmResult<T>,
+    ) -> StmResult<Arc<T>> {
         let mut setup = self.setup.lock().unwrap_or_else(PoisonError::into_inner);
-        if let Some(setup) = setup.as_ref() {
-            return Ok(setup.clone());
+        if let Some((loaded_for, loaded)) = setup.as_ref()
+            && loaded_for == &key
+        {
+            return Ok(loaded.clone());
         }
 
         let loaded = Arc::new(load()?);
-        *setup = Some(loaded.clone());
+        *setup = Some((key, loaded.clone()));
 
         Ok(loaded)
     }
@@ -106,12 +135,18 @@ impl SnarkProverSetupCache {
         parameters: &Parameters,
         merkle_tree_depth: u32,
     ) -> StmResult<Arc<SnarkProverSetup>> {
-        CERTIFICATE_SETUP.get_or_load(|| SnarkProverSetup::try_new(parameters, merkle_tree_depth))
+        CERTIFICATE_SETUP.get_or_load(
+            SetupCacheKey::try_new(parameters, merkle_tree_depth)?,
+            || SnarkProverSetup::try_new(parameters, merkle_tree_depth),
+        )
     }
 
     /// IVC setup for `parameters`, loaded once per process.
     fn ivc_setup(parameters: &Parameters) -> StmResult<Arc<IvcProverSetup>> {
-        IVC_SETUP.get_or_load(|| IvcProverSetup::try_new(parameters))
+        IVC_SETUP.get_or_load(
+            SetupCacheKey::try_new(parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?,
+            || IvcProverSetup::try_new(parameters),
+        )
     }
 }
 
@@ -127,8 +162,20 @@ mod tests {
 
     use super::*;
 
+    fn key(quorum: u64) -> SetupCacheKey {
+        SetupCacheKey::try_new(
+            &Parameters {
+                m: 9,
+                k: quorum,
+                phi_f: 0.95,
+            },
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+        )
+        .unwrap()
+    }
+
     #[test]
-    fn the_setup_is_loaded_once_and_shared_afterwards() {
+    fn the_setup_of_a_configuration_is_loaded_once_and_shared_afterwards() {
         let slot = SetupSlot::new();
         let loads = Cell::new(0);
         let load = || {
@@ -136,8 +183,8 @@ mod tests {
             Ok(loads.get())
         };
 
-        let first = slot.get_or_load(load).unwrap();
-        let second = slot.get_or_load(load).unwrap();
+        let first = slot.get_or_load(key(5), load).unwrap();
+        let second = slot.get_or_load(key(5), load).unwrap();
 
         assert_eq!(1, loads.get(), "the setup must be loaded once");
         assert!(
@@ -147,7 +194,51 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_callers_load_it_once_and_share_it() {
+    fn another_configuration_is_loaded_instead_of_reusing_the_stored_setup() {
+        let slot = SetupSlot::new();
+        let loads = Cell::new(0);
+        let load = || {
+            loads.set(loads.get() + 1);
+            Ok(loads.get())
+        };
+
+        let first = slot.get_or_load(key(5), load).unwrap();
+        let other = slot.get_or_load(key(6), load).unwrap();
+
+        assert_eq!(
+            2,
+            loads.get(),
+            "a configuration change must load its own setup"
+        );
+        assert!(
+            !Arc::ptr_eq(&first, &other),
+            "a configuration must never be served the setup of another one"
+        );
+    }
+
+    #[test]
+    fn a_configuration_that_came_back_is_loaded_again() {
+        let slot = SetupSlot::new();
+        let loads = Cell::new(0);
+        let load = || {
+            loads.set(loads.get() + 1);
+            Ok(loads.get())
+        };
+
+        slot.get_or_load(key(5), load).unwrap();
+        slot.get_or_load(key(6), load).unwrap();
+        let back = slot.get_or_load(key(5), load).unwrap();
+
+        assert_eq!(
+            3,
+            loads.get(),
+            "the slot holds one configuration, so the previous one is loaded again"
+        );
+        assert_eq!(3, *back);
+    }
+
+    #[test]
+    fn concurrent_callers_of_a_configuration_load_it_once_and_share_it() {
         let slot = SetupSlot::new();
         let loads = AtomicUsize::new(0);
         let ready = Barrier::new(4);
@@ -157,7 +248,7 @@ mod tests {
                 .map(|_| {
                     scope.spawn(|| {
                         ready.wait();
-                        slot.get_or_load(|| {
+                        slot.get_or_load(key(5), || {
                             loads.fetch_add(1, Ordering::SeqCst);
                             thread::sleep(Duration::from_millis(50));
                             Ok(1)
@@ -190,8 +281,8 @@ mod tests {
     fn a_failed_load_is_not_stored() {
         let slot: SetupSlot<u32> = SetupSlot::new();
 
-        let failure = slot.get_or_load(|| Err(anyhow!("load failed")));
-        let retry = slot.get_or_load(|| Ok(1));
+        let failure = slot.get_or_load(key(5), || Err(anyhow!("load failed")));
+        let retry = slot.get_or_load(key(5), || Ok(1));
 
         assert!(failure.is_err(), "a failed load must surface its error");
         assert_eq!(

--- a/mithril-stm/src/proof_system/snark_setup_cache.rs
+++ b/mithril-stm/src/proof_system/snark_setup_cache.rs
@@ -1,0 +1,203 @@
+//! Process-wide reuse of the SNARK prover setups.
+//!
+//! Loading a setup reads the SRS from disk, downsizes it to the circuit degree and deserializes the
+//! key pair, which the provers would otherwise pay at every aggregation. [`SnarkProverSetupCache`]
+//! loads each setup once for the lifetime of the process, at the cost of keeping the SRS and the
+//! proving keys resident.
+//!
+//! A process only ever needs one setup: the circuit is built from the protocol parameters, and
+//! changing them changes the embedded circuit verification keys, so it takes a new release of the
+//! node rather than a new epoch.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use crate::{
+    Parameters, StmResult,
+    proof_system::{halo2_ivc_snark::IvcProverSetup, halo2_snark::SnarkProverSetup},
+};
+
+/// The certificate-circuit setup of this process.
+static CERTIFICATE_SETUP: SetupSlot<SnarkProverSetup> = SetupSlot::new();
+
+/// The IVC setup of this process.
+static IVC_SETUP: SetupSlot<IvcProverSetup> = SetupSlot::new();
+
+/// A setup, loaded at most once and shared by every caller that asks for it.
+struct SetupSlot<T> {
+    /// The setup, absent until it has been loaded.
+    setup: Mutex<Option<Arc<T>>>,
+}
+
+impl<T> SetupSlot<T> {
+    /// Builds an empty slot.
+    const fn new() -> Self {
+        Self {
+            setup: Mutex::new(None),
+        }
+    }
+
+    /// Returns the setup, loading it with `load` if this is the first caller.
+    ///
+    /// Callers wait for that one load instead of racing through the expensive path. A failed load
+    /// leaves the slot empty and is retried by the next caller.
+    fn get_or_load(&self, load: impl FnOnce() -> StmResult<T>) -> StmResult<Arc<T>> {
+        let mut setup = self.setup.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(setup) = setup.as_ref() {
+            return Ok(setup.clone());
+        }
+
+        let loaded = Arc::new(load()?);
+        *setup = Some(loaded.clone());
+
+        Ok(loaded)
+    }
+}
+
+/// Whether the prover setups are reused across the aggregations of a process.
+///
+/// Reuse trades resident memory for the SRS load and the key deserialization that every aggregation
+/// would otherwise repeat. Every node reuses them today; the variant is carried by
+/// [`NonDeterministicSnarkProverFactory`](super::snark_prover_factory::NonDeterministicSnarkProverFactory)
+/// so the behavior can be selected without touching the provers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnarkProverSetupReuse {
+    /// Load each setup once per process and share it, keeping it resident.
+    Enabled,
+    /// Load a setup for every aggregation and release it with the prover, for the callers that ask
+    /// about parameters the process does not sign with.
+    Disabled,
+}
+
+impl SnarkProverSetupReuse {
+    /// Certificate-circuit setup for `parameters` and `merkle_tree_depth`, from the process cache
+    /// when reuse is enabled and freshly loaded otherwise.
+    pub(crate) fn certificate_setup(
+        &self,
+        parameters: &Parameters,
+        merkle_tree_depth: u32,
+    ) -> StmResult<Arc<SnarkProverSetup>> {
+        match self {
+            Self::Enabled => {
+                SnarkProverSetupCache::certificate_setup(parameters, merkle_tree_depth)
+            }
+            Self::Disabled => Ok(Arc::new(SnarkProverSetup::try_new(
+                parameters,
+                merkle_tree_depth,
+            )?)),
+        }
+    }
+
+    /// IVC setup for `parameters`, from the process cache when reuse is enabled and freshly loaded
+    /// otherwise.
+    pub(crate) fn ivc_setup(&self, parameters: &Parameters) -> StmResult<Arc<IvcProverSetup>> {
+        match self {
+            Self::Enabled => SnarkProverSetupCache::ivc_setup(parameters),
+            Self::Disabled => Ok(Arc::new(IvcProverSetup::try_new(parameters)?)),
+        }
+    }
+}
+
+/// Reuses the SNARK prover setups across the aggregations of a process.
+struct SnarkProverSetupCache;
+
+impl SnarkProverSetupCache {
+    /// Certificate-circuit setup for `parameters` and `merkle_tree_depth`, loaded once per process.
+    fn certificate_setup(
+        parameters: &Parameters,
+        merkle_tree_depth: u32,
+    ) -> StmResult<Arc<SnarkProverSetup>> {
+        CERTIFICATE_SETUP.get_or_load(|| SnarkProverSetup::try_new(parameters, merkle_tree_depth))
+    }
+
+    /// IVC setup for `parameters`, loaded once per process.
+    fn ivc_setup(parameters: &Parameters) -> StmResult<Arc<IvcProverSetup>> {
+        IVC_SETUP.get_or_load(|| IvcProverSetup::try_new(parameters))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn the_setup_is_loaded_once_and_shared_afterwards() {
+        let slot = SetupSlot::new();
+        let loads = Cell::new(0);
+        let load = || {
+            loads.set(loads.get() + 1);
+            Ok(loads.get())
+        };
+
+        let first = slot.get_or_load(load).unwrap();
+        let second = slot.get_or_load(load).unwrap();
+
+        assert_eq!(1, loads.get(), "the setup must be loaded once");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "both callers must share the same loaded setup"
+        );
+    }
+
+    #[test]
+    fn concurrent_callers_load_it_once_and_share_it() {
+        let slot = SetupSlot::new();
+        let loads = AtomicUsize::new(0);
+        let ready = Barrier::new(4);
+
+        let setups = thread::scope(|scope| {
+            let handles: Vec<_> = (0..4)
+                .map(|_| {
+                    scope.spawn(|| {
+                        ready.wait();
+                        slot.get_or_load(|| {
+                            loads.fetch_add(1, Ordering::SeqCst);
+                            thread::sleep(Duration::from_millis(50));
+                            Ok(1)
+                        })
+                        .unwrap()
+                    })
+                })
+                .collect();
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        assert_eq!(
+            1,
+            loads.load(Ordering::SeqCst),
+            "concurrent callers must not race through the expensive load"
+        );
+        for setup in &setups {
+            assert!(
+                Arc::ptr_eq(&setups[0], setup),
+                "every caller must share the same loaded setup"
+            );
+        }
+    }
+
+    #[test]
+    fn a_failed_load_is_not_stored() {
+        let slot: SetupSlot<u32> = SetupSlot::new();
+
+        let failure = slot.get_or_load(|| Err(anyhow!("load failed")));
+        let retry = slot.get_or_load(|| Ok(1));
+
+        assert!(failure.is_err(), "a failed load must surface its error");
+        assert_eq!(
+            1,
+            *retry.unwrap(),
+            "a failed load must leave the slot empty so the next caller retries"
+        );
+    }
+}

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -14,7 +14,7 @@ use crate::{
     AggregateSignatureError, AncillaryProverData, AncillaryVerifierData,
     proof_system::{
         NonDeterministicSnarkProverFactory, SnarkAggregateSignatureProver, SnarkClerk,
-        SnarkProverFactory, SnarkVerifierData,
+        SnarkProverFactory, SnarkProverSetupReuse, SnarkVerifierData,
         halo2_ivc_snark::{
             IvcChainStepBundle, IvcOffCircuitChecker, IvcVerifierData, MithrilIvcOffCircuitChecker,
         },
@@ -59,7 +59,9 @@ impl<D: MembershipDigest> Clerk<D> {
                 .has_snark_verification_keys()
                 .then(|| SnarkClerk::new_clerk_from_signer(signer)),
             #[cfg(feature = "future_snark")]
-            snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
+            snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory::new(
+                SnarkProverSetupReuse::Enabled,
+            )),
             #[cfg(feature = "future_snark")]
             ivc_off_circuit_checker: Arc::new(MithrilIvcOffCircuitChecker),
             phantom_data: PhantomData,
@@ -81,7 +83,9 @@ impl<D: MembershipDigest> Clerk<D> {
                 SnarkClerk::new_clerk_from_closed_key_registration(parameters, closed_registration)
             }),
             #[cfg(feature = "future_snark")]
-            snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory),
+            snark_prover_factory: Arc::new(NonDeterministicSnarkProverFactory::new(
+                SnarkProverSetupReuse::Enabled,
+            )),
             #[cfg(feature = "future_snark")]
             ivc_off_circuit_checker: Arc::new(MithrilIvcOffCircuitChecker),
             phantom_data: PhantomData,


### PR DESCRIPTION
## Content

This PR includes the **changes that stop a node from rebuilding its SNARK prover setup for every aggregation**:

- Key the circuit key cache by configuration: it compared entries against the embedded production verification key, so any other parameters were always stale and every aggregation re-derived both key pairs.
- Reuse the loaded setups across a process through the prover factory, as a policy on `NonDeterministicSnarkProverFactory::new`: enabled for the clerk, disabled for the circuit key digest computation.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

- Measured at the end-to-end parameters on 4 cores: 
  - deriving the IVC setup 293 s
  - materializing it from the on-disk cache 239 s
  - the proof itself 165 s.
- Before this PR every signing round paid the derivation, now a process pays it once.
- In a real end-to-end run, the aggregation cycle producing one certificate went from 491 s to 93 s.
- The on-disk cache barely helps alone: deserializing the 1GB recursive proving key rebuilds the cosets with FFTs, nearly as costly as deriving them, so keeping the setup in memory is what removes the cost.

## Issue(s)
Closes #3424 
